### PR TITLE
csv overrides

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
+    "python.analysis.stubPath": "/Applications/Talon.app/Contents/Resources/python/lib/python3.9/site-packages",
     "python.formatting.provider": "black"
 }

--- a/README.md
+++ b/README.md
@@ -1,14 +1,17 @@
 # Cursorless talon
 
-This repository contains the talon side of [Cursorless](https://marketplace.visualstudio.com/items?itemName=pokey.cursorless).  
+This repository contains the talon side of [Cursorless](https://marketplace.visualstudio.com/items?itemName=pokey.cursorless).
 
 ## Documentation
+
 Full documentation can be found in [docs](docs/), or by saying `"cursorless docs"`. Once you understand the concepts, you can pull up a cheat cheat for reference using the command `"cursorless help"`.
 
 ## Installation
+
 First, install the dependencies:
 
 ### Dependencies
+
 1. Install [Talon](https://talonvoice.com/)
 2. Install [knausj_talon](https://github.com/knausj85/knausj_talon). Note that
    even a heavily modified version of knausj should be fine, but make sure you
@@ -17,13 +20,14 @@ First, install the dependencies:
    If rebasing is too painful, or if you are not a user of knausj, you can just
    clone [the command
    client](https://github.com/pokey/talon-vscode-command-client) into your
-   talon user directory. You may need a couple other things from knausj but nothing major.  Please file an issue if you have trouble getting this repo to work without knausj.
+   talon user directory. You may need a couple other things from knausj but nothing major. Please file an issue if you have trouble getting this repo to work without knausj.
 3. Install [VSCode](https://code.visualstudio.com/)
 4. Install the [VSCode talon extension pack](https://marketplace.visualstudio.com/items?itemName=pokey.talon)
 5. Install the [Cursorless VSCode extension](https://marketplace.visualstudio.com/items?itemName=pokey.cursorless)
 6. Follow the instructions below to install cursorless-vscode itself.
 
 ### Installing this repo
+
 #### Linux & Mac
 
 Clone repo into `~/.talon/user`
@@ -32,7 +36,7 @@ Clone repo into `~/.talon/user`
 cd ~/.talon/user
 git clone https://github.com/pokey/cursorless-talon cursorless-talon
 ```
-    
+
 Alternatively, access the directory by right clicking the Talon icon in taskbar, clicking Scripting>Open ~/talon, and navigating to user.
 
 The folder structure should look something like the below:
@@ -49,15 +53,15 @@ The folder structure should look something like the below:
 
 #### Windows
 
-Clone repo into `%AppData%\Talon\user` 
+Clone repo into `%AppData%\Talon\user`
 
 ```insert code:
 cd %AppData%\Talon\user
 git clone https://github.com/pokey/cursorless-talon cursorless-talon
 ```
-    
+
 Alternatively, access the directory by right clicking the Talon icon in taskbar, clicking Scripting>Open ~/talon, and navigating to user.
-    
+
 The folder structure should look something like the below:
 
 ```insert code:

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,11 +1,15 @@
 # Cursorless - Instructions
+
 You may find it helpful to start with the [tutorial video](https://www.youtube.com/watch?v=JxcNW0hnfTk).
 
 Once you understand the concepts, you can pull up a cheat cheat for reference using the command `"cursorless help"`.
 
 You can get back to these docs by saying `"cursorless docs"`.
 
+Note: If you'd like to customize any of the spoken forms, please see the [documentation](customization.md).
+
 ## Table of contents
+
 - [Table of contents](#table-of-contents)
 - [Overview](#overview)
 - [Targets](#targets)
@@ -40,27 +44,31 @@ You can get back to these docs by saying `"cursorless docs"`.
   - [Show definition/reference/quick fix](#show-definitionreferencequick-fix)
   - [Fold/unfold](#foldunfold)
   - [Extract](#extract)
-  
 
 ## Overview
+
 Every cursorless command consists of an action performed on a target. For example, the command `"chuck blue air"` deletes the token with a blue hat over the `"a"`. In this command, the action is `"chuck"` (delete), and the target is `"blue air"`.
 
 ## Targets
+
 There are two types of targets: primitive targets and compound targets. Compound targets are constructed from primitive targets, so let's begin with primitive targets.
 
 ### Primitive targets
+
 A primitive target consists of a mark and one or more optional modifiers. The simplest primitive targets just consist of a mark without any modifiers, so let's begin with those
 
 #### Marks
+
 There are several types of marks:
 
 ##### Decorated symbol
+
 This is the first type of mark you'll notice when you start using cursorless. You'll see that for every token on the screen, one of its characters will have a hat on top of it. We can refer to the given token by saying the name of the character that has a hat, along with the color if the hat is not gray:
 
-* `"air"` (if the color is gray)
-* `"blue bat"`
-* `"blue dash"`
-* `"blue five"`
+- `"air"` (if the color is gray)
+- `"blue bat"`
+- `"blue dash"`
+- `"blue five"`
 
 The general form of this type of mark is:
 
@@ -69,243 +77,267 @@ The general form of this type of mark is:
 Combining this with an action, we might say `"take blue air"` to select the token containing letter `'a'` with a blue hat over it.
 
 ###### Colors
+
 The following colors are supported. As mentioned above, note that gray is optional: `"gray air"` and `"air"` are equivalent
 
-|Command|Visible color|
----|---
-|`"gray"`|default|
-|`"blue"`|blue|
-|`"green"`|green|
-|`"rose"`|red|
-|`"squash"`|yellow|
-|`"plum"`|mauve|
-
+| Command    | Visible color |
+| ---------- | ------------- |
+| `"gray"`   | default       |
+| `"blue"`   | blue          |
+| `"green"`  | green         |
+| `"rose"`   | red           |
+| `"squash"` | yellow        |
+| `"plum"`   | mauve         |
 
 ##### `"this"`
+
 The word `"this"` can be used as a mark to refer to the current cursor(s) or selection(s). Note that when combined with a modifier, the `"this"` mark can be omitted, and it will be implied.
 
-* `chuck this`
-* `take this funk`
-* `pre funk`
-* `chuck line`
+- `chuck this`
+- `take this funk`
+- `pre funk`
+- `chuck line`
 
 ##### `"that"`
+
 The word `"that"` can be used as a mark to refer to the target of the previous cursorless command.
 
-* `"pre that"`
-* `"round wrap that"`
+- `"pre that"`
+- `"round wrap that"`
 
 #### Modifiers
-Modifiers can be applied to any mark to modify its extent. This is commonly used to refer to larger syntactic elements within a source code document. 
+
+Modifiers can be applied to any mark to modify its extent. This is commonly used to refer to larger syntactic elements within a source code document.
 
 Note that if the mark is `"this"`, and you have multiple cursors, the modifiers will be applied to each cursor individually.
 
 ##### Syntactic scopes
-|Term|Syntactic element|
----|---
- `"arg"` | function parameter or function call argument
- `"arrow"` | anonymous lambda function
- `"call"` | function call, eg `foo(1, 2)`
- `"class"` | class definition
- `"class name"` | the name in a class declaration
- `"comment"` | comment
- `"element"` | list element
- `"funk"` | function definition
- `"funk name"` | the name in a function declaration
- `"if"` | if statement
- `"key"` | key in a map / object
- `"lambda"` | equivalent to `"arrow"`
- `"list"` | list
- `"map"` | map / object
- `"name"` | the name in a declaration (eg function name)
- `"pair"` | an entry in a map / object
- `"state"` | a statement, eg `let foo;`
- `"string"` | string
- `"type"` | a type annotation or declaration
- `"value"` | a value in a map / object
 
-For example, `"take funk blue air"` selects the function containing the token with a blue hat over the letter `'a'`. 
+| Term           | Syntactic element                            |
+| -------------- | -------------------------------------------- |
+| `"arg"`        | function parameter or function call argument |
+| `"arrow"`      | anonymous lambda function                    |
+| `"call"`       | function call, eg `foo(1, 2)`                |
+| `"class"`      | class definition                             |
+| `"class name"` | the name in a class declaration              |
+| `"comment"`    | comment                                      |
+| `"element"`    | list element                                 |
+| `"funk"`       | function definition                          |
+| `"funk name"`  | the name in a function declaration           |
+| `"if"`         | if statement                                 |
+| `"key"`        | key in a map / object                        |
+| `"lambda"`     | equivalent to `"arrow"`                      |
+| `"list"`       | list                                         |
+| `"map"`        | map / object                                 |
+| `"name"`       | the name in a declaration (eg function name) |
+| `"pair"`       | an entry in a map / object                   |
+| `"state"`      | a statement, eg `let foo;`                   |
+| `"string"`     | string                                       |
+| `"type"`       | a type annotation or declaration             |
+| `"value"`      | a value in a map / object                    |
+
+For example, `"take funk blue air"` selects the function containing the token with a blue hat over the letter `'a'`.
 
 ##### `"every"`
+
 The command `"every"` can be used to select a syntactic element and all of its matching siblings.
 
-* `"take every key air"`
-* `"take every funk air"`
-* `"take every key"` (if cursor is currently within a key)
+- `"take every key air"`
+- `"take every funk air"`
+- `"take every key"` (if cursor is currently within a key)
 
-For example, the command `take every key [blue] air` will select every key in the map/object/dict including the token with a blue hat over the letter 'a'. 
+For example, the command `take every key [blue] air` will select every key in the map/object/dict including the token with a blue hat over the letter 'a'.
 
 ##### Sub-token modifiers
+
 ###### `"word"`
+
 If you need to refer to the individual words within a `camelCase`/`kebab-case`/`snake_case` token, you can use the `"word"` modifier. For example,
 
-* `"second word air"`
-* `"second through fourth word air"`
-* `"last word air"`
+- `"second word air"`
+- `"second through fourth word air"`
+- `"last word air"`
 
 For example, the following command:
 
-    "take second through fourth word blue air"  
+    "take second through fourth word blue air"
 
 Selects the second, third and fourth word in the token containing letter 'a' with a blue hat.
 
 ###### `"char"`
+
 You can also refer to individual characters within a token:
 
-* `"second char air"`
-* `"second through fourth char air"`
-* `"last char air"`
+- `"second char air"`
+- `"second through fourth char air"`
+- `"last char air"`
 
 ##### `"line"`
+
 The word `"line"` can be used to expand a target to refer to entire lines rather than individual tokens:
 
 eg:  
 `take line [blue] air`  
-Selects the line including the token containing letter 'a' with a blue hat. 
+Selects the line including the token containing letter 'a' with a blue hat.
 
 ##### `"file"`
-The word file can be used to expand the target to refer to the entire file. 
 
-* `"copy file"`
-* `"take file"`
-* `"take file blue air"`
+The word file can be used to expand the target to refer to the entire file.
 
-For example, `"take file [blue] air"` selects the file including the token containing letter 'a' with a blue hat. 
+- `"copy file"`
+- `"take file"`
+- `"take file blue air"`
+
+For example, `"take file [blue] air"` selects the file including the token containing letter 'a' with a blue hat.
 
 ### Compound targets
+
 Individual targets can be combined into compound targets to make bigger targets or refer to multiple selections at the same time.
 
 #### Range targets
+
 A range target uses one primitive target as its start and another as its end to form a range from the start to the end. For example, `"air past bat"` refers to the range from the token with a hat over its 'a' to a token with a hat over its 'b'.
 
 Note that if the first target is omitted, the start of the range will be the current selection(s).
 
-* `"take [blue] air past [green] bat"`
-* `"take past [blue] air"`
-* `"take funk [blue] air past [blue] bat"` (note end of range inherits `"funk"`)
-* `"take funk [blue] air past token [blue] bat"`
-* `"take past before [blue] air"`
-* `"take after [blue] air past before [blue] bat"`
-* `"take past end of line"`
-* `"take past start of line"`
-* `"take [blue] air past end of line"` (but see [pokey/cursorless-vscode#4](https://github.com/pokey/cursorless-vscode/issues/4))
+- `"take [blue] air past [green] bat"`
+- `"take past [blue] air"`
+- `"take funk [blue] air past [blue] bat"` (note end of range inherits `"funk"`)
+- `"take funk [blue] air past token [blue] bat"`
+- `"take past before [blue] air"`
+- `"take after [blue] air past before [blue] bat"`
+- `"take past end of line"`
+- `"take past start of line"`
+- `"take [blue] air past end of line"` (but see [pokey/cursorless-vscode#4](https://github.com/pokey/cursorless-vscode/issues/4))
 
 eg:  
 `take blue air past green bat`  
 Selects the range from the token containing letter 'a' with a blue hat past the token containing letter 'b' with a green hat.
 
 #### List targets
+
 In addition to range targets, cursorless supports list targets, which allow you to refer to multiple targets at the same time. When combined with the `"take"` action, this will result in multiple cursors, for other actions, such as `"chuck"` the action will be applied to all the different targets at once.
 
-* `"take [blue] air and [green] bat"`
-* `"take funk [blue] air and [green] bat"` (note second target inherits `"funk"`)
-* `"take funk [blue] air and token [green] bat"` [blue] air and [green] bat
-* `"take air and bat past cap"`
+- `"take [blue] air and [green] bat"`
+- `"take funk [blue] air and [green] bat"` (note second target inherits `"funk"`)
+- `"take funk [blue] air and token [green] bat"` [blue] air and [green] bat
+- `"take air and bat past cap"`
 
 eg:  
 `take blue air and green bat`  
 Selects both the token containing letter 'a' with a blue hat AND the token containing 'b' with a green hat.
 
 ## Actions
+
 In any cursorless command the action defines what happens to the given target, for example deleting the target (`"chuck"`) or moving the cursor to select the target (`"take"`).
 
 ### Cursor movement
+
 Despite the name cursorless, some of the most basic commands in cursorless are for moving the cursor.
 
 Note that when combined with list targets, these commands will result in multiple cursors
 
-* `"take"`: Selects the given target
-* `"pre"`: Places the cursor before the given target
-* `"post"`: Places the cursor after the given target
+- `"take"`: Selects the given target
+- `"pre"`: Places the cursor before the given target
+- `"post"`: Places the cursor after the given target
 
 eg:  
 `pre blue air`  
 Moves the cursor to before the token containing letter 'a' with a blue hat.
 
 ### Delete
+
 This command can be used to delete a target without moving the cursor
 
-* `"chuck"`
+- `"chuck"`
 
 eg:  
 `chuck blue air`  
 Deletes the token containing letter 'a' with a blue hat.
 
 ### Changing a target
+
 This command will delete a target and leave the cursor where the target used to be, making it easy to change a target
 
-* `"clear"`
+- `"clear"`
 
 ### Cut / copy
-* `"cut"`
-* `"copy"`
+
+- `"cut"`
+- `"copy"`
 
 eg:  
 `copy blue air`  
 Copies the token containing letter 'a' with a blue hat.
 
 ### Swap
+
 Swaps two targets. If the first target is omitted, it will refer to the current selection. If the targets are list targets they will be zipped together.
- 
-* `"swap <TARGET 1> with <TARGET 2>"`
-* `"swap with <TARGET>"`
+
+- `"swap <TARGET 1> with <TARGET 2>"`
+- `"swap with <TARGET>"`
 
 eg:  
-`swap blue air with green bat`  
+`swap blue air with green bat`
 
 Swaps the given tokens.
 
 ### Insert empty lines
-* `"drink"`: Inserts a new line above the current line, and moves the cursor to the newly created line
-* `"pour"`: Inserts a new line below the current line, and moves the cursor to the newly created line
+
+- `"drink"`: Inserts a new line above the current line, and moves the cursor to the newly created line
+- `"pour"`: Inserts a new line below the current line, and moves the cursor to the newly created line
 
 eg:  
 `pour blue air`  
 Insert empty line below the token containing letter 'a' with a blue hat.
 
 ### Rename
+
 Executes vscode rename action on the given target
 
-* `"rename"`
+- `"rename"`
 
 eg:  
 `rename blue air`  
 Rename the token containing letter 'a' with a blue hat.
 
 ### Scroll
+
 Scrolls a given target to the top, center or bottom of the screen.
 
-* `"top"`
-* `"center"`
-* `"bottom"`
+- `"top"`
+- `"center"`
+- `"bottom"`
 
 eg `top blue air` scrolls the line containing the letter 'a' with a blue hat to the top of the screen.
 
 ### Insert/Use/Repeat
+
 The `"bring"` command can be used to replace one target with another, or to use a target at the current cursor position.
 
-* `"bring <TARGET>"`: Inserts the given target at the cursor position
-* `"bring <TARGET 1> to <TARGET 2>"`
+- `"bring <TARGET>"`: Inserts the given target at the cursor position
+- `"bring <TARGET 1> to <TARGET 2>"`
 
 eg:  
 `bring blue air to green bat`  
 Replaces the token containing letter 'b' with a green hat using the token containing letter 'a' with a blue hat.
 
 ### Wrap
+
 The wrap commands can be used to wrap a given target with a pair of symbols
 
-|Term|Symbol inserted before target|Symbol inserted after target|
----|---|---
-`"square wrap"` | `[` | `]`
-`"round wrap"` | `(` | `)`
-`"curly wrap"` | `{` | `}`
-`"(diamond \| angle) wrap"` | `<` | `>`
-`"quad wrap"` | `"` | `"`
-`"twin wrap"` | `'` | `'`
-`"escaped quad wrap"` | `\"` | `\"`
-`"escaped twin wrap"` | `\'` | `\'`
-`"line wrap"` | `\n` | `\n`
-`"wrap <TARGET> with funk <FUNCTION_NAME>"` | `<FUNCTION_NAME>(` | `)`
+| Term                                        | Symbol inserted before target | Symbol inserted after target |
+| ------------------------------------------- | ----------------------------- | ---------------------------- |
+| `"square wrap"`                             | `[`                           | `]`                          |
+| `"round wrap"`                              | `(`                           | `)`                          |
+| `"curly wrap"`                              | `{`                           | `}`                          |
+| `"(diamond \| angle) wrap"`                 | `<`                           | `>`                          |
+| `"quad wrap"`                               | `"`                           | `"`                          |
+| `"twin wrap"`                               | `'`                           | `'`                          |
+| `"escaped quad wrap"`                       | `\"`                          | `\"`                         |
+| `"escaped twin wrap"`                       | `\'`                          | `\'`                         |
+| `"line wrap"`                               | `\n`                          | `\n`                         |
+| `"wrap <TARGET> with funk <FUNCTION_NAME>"` | `<FUNCTION_NAME>(`            | `)`                          |
 
 eg:  
 `square wrap blue air`  
@@ -313,32 +345,34 @@ Wraps the token containing letter 'a' with a blue hat in square brackets.
 
 ### Show definition/reference/quick fix
 
-* `"def show"`
-* `"ref show"`
-* `"hover show"`
-* `"quick fix"`
+- `"def show"`
+- `"ref show"`
+- `"hover show"`
+- `"quick fix"`
 
 eg:  
 `def show blue air`  
 Shows definition for the token containing letter 'a' with a blue hat.
 
 ### Fold/unfold
+
 Note that these actions will only work if referring to the entire target, not just the first line (see [#72](https://github.com/pokey/cursorless-vscode/issues/72)).
 
-* `"fold"`
-* `"unfold"`
+- `"fold"`
+- `"unfold"`
 
 eg:  
 `fold funk blue air`  
 Fold the function with the token containing letter 'a' with a blue hat.
 
 ### Extract
+
 Extracts a target as a variable using the VSCode refactor action
 
-* `"extract"`
-* `"extract {TARGET} as hello world"`
+- `"extract"`
+- `"extract {TARGET} as hello world"`
 
 eg:  
-`extract call air`  
+`extract call air`
 
 Extracts the function call containing the decorated 'a' into its own variable.

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -14,9 +14,13 @@ csvs found in the `cursorless-settings` subdirectory of your user folder. On
 Linux and Mac, the directory is `~/.talon/user/cursorless-settings`. On
 Windows, it is `%AppData%\Talon\user\cursorless-settings`.
 
-Note that these csv's have no header column, support empty lines, and support
-comment lines beginning with `#`. All spoken forms and cursorless identifiers
-will automatically be stripped of leading and trailing whitespace.
+Note that these csv's
+
+- have no header column,
+- support empty lines,
+- support comment lines beginning with `#`.
+- ignore any leading / trailing whitespace on spoken forms and cursorless
+  identifiers
 
 ### Changing a spoken form
 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -3,7 +3,7 @@
 Many of the words used in cursorless can be easily customized without needing
 to fork cursorless or modify the talon / python files contained therein. If you
 find that your customization needs cannot be met without making changes to
-cursorless files, please file an issue so we can try to improve customization.
+cursorless files, please [file an issue](https://github.com/pokey/cursorless-talon/issues/new) so we can try to improve customization.
 
 ## Cursorless settings csvs
 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -1,0 +1,31 @@
+# Customization
+
+Many of the words used in cursorless can be easily customized without needing
+to fork cursorless or modify the talon / python files contained therein. If you
+find that your customization needs cannot be met without making changes to
+cursorless files, please file an issue so we can try to improve customization.
+
+## Cursorless settings csvs
+
+The words for actions, scope types, colors, etc can be customized using the
+csvs found in the `cursorless-settings` subdirectory of your user folder. On
+Linux and Mac, the directory is `~/.talon/user/cursorless-settings`. On
+Windows, it is `%AppData%\Talon\user\cursorless-settings`.
+
+Note that these csv's have no header column, and support empty lines, as well as comment lines beginning with `#`. All spoken forms and cursorless identifiers will automatically be stripped of leading and trailing whitespace.
+
+### Changing a word
+
+Simply modify the spoken form in the first column of any of the csvs above to
+change the word you'd like to use.
+
+### New features
+
+When new actions, scope types, etc are added, Cursorless will detect that they're missing from your csvs and append the default term to the end. You can then feel free to modify the spoken form if you'd like to change it.
+
+### Removing a term
+
+If you'd like to remove an action, scope type, etc, you can simply set the
+spoken form in the first column to `-`. Please don't delete any lines, as that
+will trigger cursorless to automatically add the spoken form back on talon
+restart.

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -14,11 +14,11 @@ csvs found in the `cursorless-settings` subdirectory of your user folder. On
 Linux and Mac, the directory is `~/.talon/user/cursorless-settings`. On
 Windows, it is `%AppData%\Talon\user\cursorless-settings`.
 
-Note that these csv's
+Note that these csv's:
 
 - have no header column,
 - support empty lines,
-- support comment lines beginning with `#`.
+- support comment lines beginning with `#`, and
 - ignore any leading / trailing whitespace on spoken forms and cursorless
   identifiers
 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -12,7 +12,7 @@ improve customization.
 The spoken forms for actions, scope types, colors, etc can be customized using the
 csvs found in the `cursorless-settings` subdirectory of your user folder. On
 Linux and Mac, the directory is `~/.talon/user/cursorless-settings`. On
-Windows, it is `%AppData%\Talon\user\cursorless-settings`.
+Windows, it is `%AppData%\Talon\user\cursorless-settings`.  The directory location can be customized using the `user.cursorless_settings_directory` Talon setting.  If the path is relative, it will be taken relative to your Talon user directory.
 
 Note that these csv's:
 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -1,23 +1,27 @@
 # Customization
 
-Many of the words used in cursorless can be easily customized without needing
-to fork cursorless or modify the talon / python files contained therein. If you
-find that your customization needs cannot be met without making changes to
-cursorless files, please [file an issue](https://github.com/pokey/cursorless-talon/issues/new) so we can try to improve customization.
+Many of the spoken forms used in cursorless can be easily customized without
+needing to fork cursorless or modify the talon / python files contained
+therein. If you find that your customization needs cannot be met without making
+changes to cursorless files, please [file an
+issue](https://github.com/pokey/cursorless-talon/issues/new) so we can try to
+improve customization.
 
 ## Cursorless settings csvs
 
-The words for actions, scope types, colors, etc can be customized using the
+The spoken forms for actions, scope types, colors, etc can be customized using the
 csvs found in the `cursorless-settings` subdirectory of your user folder. On
 Linux and Mac, the directory is `~/.talon/user/cursorless-settings`. On
 Windows, it is `%AppData%\Talon\user\cursorless-settings`.
 
-Note that these csv's have no header column, and support empty lines, as well as comment lines beginning with `#`. All spoken forms and cursorless identifiers will automatically be stripped of leading and trailing whitespace.
+Note that these csv's have no header column, support empty lines, and support
+comment lines beginning with `#`. All spoken forms and cursorless identifiers
+will automatically be stripped of leading and trailing whitespace.
 
-### Changing a word
+### Changing a spoken form
 
-Simply modify the spoken form in the first column of any of the csvs above to
-change the word you'd like to use.
+Simply modify the spoken form in the first column of any of the csvs in the
+directory above to change the spoken you'd like to use. The new spoken form will be usable immediately.
 
 ### New features
 

--- a/src/actions/actions.py
+++ b/src/actions/actions.py
@@ -1,3 +1,4 @@
+from ..conventions import get_cursorless_list_name
 from talon import Module, actions, app
 from dataclasses import dataclass
 from ..csv_overrides import init_csv_and_watch_changes
@@ -17,6 +18,8 @@ class MakeshiftAction:
     post_command_sleep: float = 0
 
 
+# NOTE: Please do not change these dicts.  Use the CSVs for customization.
+# See https://github.com/pokey/cursorless-talon/blob/master/docs/customization.md
 makeshift_actions = [
     MakeshiftAction("define", "revealDefinition", "editor.action.revealDefinition"),
     MakeshiftAction("hover", "showHover", "editor.action.showHover"),
@@ -38,6 +41,8 @@ class CallbackAction:
     callback: callable
 
 
+# NOTE: Please do not change these dicts.  Use the CSVs for customization.
+# See https://github.com/pokey/cursorless-talon/blob/master/docs/customization.md
 callbacks = [
     CallbackAction("call", "call", run_call_action),
     CallbackAction("scout", "find", run_find_action),
@@ -50,6 +55,8 @@ callbacks_map = {callback.identifier: callback.callback for callback in callback
 mod.list("cursorless_simple_action", desc="Supported actions for cursorless navigation")
 
 
+# NOTE: Please do not change these dicts.  Use the CSVs for customization.
+# See https://github.com/pokey/cursorless-talon/blob/master/docs/customization.md
 simple_actions = {
     "bottom": "scrollToBottom",
     "breakpoint": "setBreakpoint",
@@ -105,6 +112,8 @@ def run_makeshift_action(action: str, targets: dict):
     actions.sleep(makeshift_action.post_command_sleep)
 
 
+# NOTE: Please do not change these dicts.  Use the CSVs for customization.
+# See https://github.com/pokey/cursorless-talon/blob/master/docs/customization.md
 default_values = {
     "simple_action": simple_actions,
     "swap_action": {"swap": "swap"},
@@ -113,7 +122,7 @@ default_values = {
     "reformat_action": {"format": "reformat"},
 }
 
-ACTION_LIST_NAMES = [f"user.cursorless_{key}" for key in default_values]
+ACTION_LIST_NAMES = [get_cursorless_list_name(key) for key in default_values]
 
 
 def on_ready():

--- a/src/actions/actions.py
+++ b/src/actions/actions.py
@@ -117,14 +117,15 @@ all_actions = [
     ["reformat", {"format": "reformat"}],
 ]
 
-action_list_names = [line[0] for line in all_actions]
+action_list_names = [
+    "user.cursorless_{0}_action".format(line[0]) for line in all_actions
+]
 default_action_values = [line[1] for line in all_actions]
 
 
 def on_csv_change(updated_dicts):
     for i in range(len(action_list_names)):
-        list_name = action_list_names[i]
-        ctx.lists[f"self.cursorless_{list_name}_action"] = updated_dicts[i]
+        ctx.lists[action_list_names[i]] = updated_dicts[i]
 
 
 def on_ready():

--- a/src/actions/actions.py
+++ b/src/actions/actions.py
@@ -1,4 +1,4 @@
-from talon import Context, Module, actions, app
+from talon import Module, actions, app
 from dataclasses import dataclass
 from ..csv_overrides import init_csv_and_watch_changes
 from .homophones import run_homophones_action
@@ -6,8 +6,6 @@ from .find import run_find_action
 from .call import run_call_action
 
 mod = Module()
-
-ctx = Context()
 
 
 @dataclass
@@ -109,27 +107,19 @@ def run_makeshift_action(action: str, targets: dict):
     actions.sleep(makeshift_action.post_command_sleep)
 
 
-all_actions = [
-    ["simple", simple_actions],
-    ["swap", {"swap": "swap"}],
-    ["move_bring", {"bring": "bring", "move": "move"}],
-    ["wrap", {"wrap": "wrap"}],
-    ["reformat", {"format": "reformat"}],
-]
+default_values = {
+    "simple_action": simple_actions,
+    "swap_action": {"swap": "swap"},
+    "move_bring_action": {"bring": "bring", "move": "move"},
+    "wrap_action": {"wrap": "wrap"},
+    "reformat_action": {"format": "reformat"},
+}
 
-action_list_names = [
-    "user.cursorless_{0}_action".format(line[0]) for line in all_actions
-]
-default_action_values = [line[1] for line in all_actions]
-
-
-def on_csv_change(updated_dicts):
-    for i in range(len(action_list_names)):
-        ctx.lists[action_list_names[i]] = updated_dicts[i]
+action_list_names = [f"user.cursorless_{key}" for key in default_values]
 
 
 def on_ready():
-    init_csv_and_watch_changes("actions", default_action_values, on_csv_change)
+    init_csv_and_watch_changes("actions", default_values)
 
 
 app.register("ready", on_ready)

--- a/src/actions/actions.py
+++ b/src/actions/actions.py
@@ -114,7 +114,7 @@ all_actions = [
     ["swap", {"swap": "swap"}],
     ["move_bring", {"bring": "bring", "move": "move"}],
     ["wrap", {"wrap": "wrap"}],
-    ["reformat", {"format": "format"}],
+    ["reformat", {"format": "reformat"}],
 ]
 
 action_list_names = [line[0] for line in all_actions]

--- a/src/actions/actions.py
+++ b/src/actions/actions.py
@@ -1,5 +1,6 @@
-from talon import Context, Module, actions
+from talon import Context, Module, actions, app
 from dataclasses import dataclass
+from ..csv_overrides import watch_csv
 from .homophones import run_homophones_action
 from .find import run_find_action
 from .call import run_call_action
@@ -50,8 +51,7 @@ callbacks = [
 callbacks_map = {callback.action: callback.callback for callback in callbacks}
 
 
-mod.list("cursorless_simple_action", desc="Supported actions for cursorless navigation")
-ctx.lists["self.cursorless_simple_action"] = {
+simple_actions = {
     "bottom": "scrollToBottom",
     "breakpoint": "setBreakpoint",
     "carve": "cut",
@@ -84,6 +84,9 @@ ctx.lists["self.cursorless_simple_action"] = {
     **{callback.term: callback.action for callback in callbacks},
 }
 
+mod.list("cursorless_simple_action", desc="Supported actions for cursorless navigation")
+ctx.lists["self.cursorless_simple_action"] = simple_actions
+
 
 @mod.action_class
 class Actions:
@@ -104,3 +107,10 @@ def run_makeshift_action(action: str, targets: dict):
     actions.sleep(makeshift_action.pre_command_sleep)
     actions.user.vscode(makeshift_action.vscode_command_id)
     actions.sleep(makeshift_action.post_command_sleep)
+
+
+def on_watch():
+    print("On watch")
+
+
+app.register("ready", lambda: watch_csv("actions", simple_actions, on_watch))

--- a/src/actions/actions.py
+++ b/src/actions/actions.py
@@ -1,4 +1,3 @@
-from ..conventions import get_cursorless_list_name
 from talon import Module, actions, app
 from dataclasses import dataclass
 from ..csv_overrides import init_csv_and_watch_changes
@@ -122,7 +121,7 @@ default_values = {
     "reformat_action": {"format": "reformat"},
 }
 
-ACTION_LIST_NAMES = [get_cursorless_list_name(key) for key in default_values]
+ACTION_LIST_NAMES = default_values.keys()
 
 
 def on_ready():

--- a/src/actions/actions.py
+++ b/src/actions/actions.py
@@ -8,9 +8,6 @@ from .call import run_call_action
 mod = Module()
 
 ctx = Context()
-ctx.matches = r"""
-tag: user.cursorless
-"""
 
 
 @dataclass
@@ -54,6 +51,9 @@ callbacks = [
 callbacks_map = {callback.identifier: callback.callback for callback in callbacks}
 
 
+mod.list("cursorless_simple_action", desc="Supported actions for cursorless navigation")
+
+
 simple_actions = {
     "bottom": "scrollToBottom",
     "breakpoint": "setBreakpoint",
@@ -87,9 +87,6 @@ simple_actions = {
     **{callback.term: callback.identifier for callback in callbacks},
 }
 
-mod.list("cursorless_simple_action", desc="Supported actions for cursorless navigation")
-ctx.lists["self.cursorless_simple_action"] = simple_actions
-
 
 @mod.action_class
 class Actions:
@@ -112,13 +109,26 @@ def run_makeshift_action(action: str, targets: dict):
     actions.sleep(makeshift_action.post_command_sleep)
 
 
+all_actions = [
+    ["simple", simple_actions],
+    ["swap", {"swap": "swap"}],
+    ["move_bring", {"bring": "bring", "move": "move"}],
+    ["wrap", {"wrap": "wrap"}],
+    ["reformat", {"format": "format"}],
+]
+
+action_list_names = [line[0] for line in all_actions]
+default_action_values = [line[1] for line in all_actions]
+
+
 def on_csv_change(updated_dicts):
-    print("On watch")
-    print(updated_dicts)
+    for i in range(len(action_list_names)):
+        list_name = action_list_names[i]
+        ctx.lists[f"self.cursorless_{list_name}_action"] = updated_dicts[i]
 
 
 def on_ready():
-    init_csv_and_watch_changes("actions", [simple_actions], on_csv_change)
+    init_csv_and_watch_changes("actions", default_action_values, on_csv_change)
 
 
 app.register("ready", on_ready)

--- a/src/actions/actions.py
+++ b/src/actions/actions.py
@@ -18,11 +18,9 @@ class MakeshiftAction:
 
 
 makeshift_actions = [
-    MakeshiftAction("drink cell", "editNewCellAbove", "jupyter.insertCellAbove"),
     MakeshiftAction("define", "revealDefinition", "editor.action.revealDefinition"),
     MakeshiftAction("hover", "showHover", "editor.action.showHover"),
     MakeshiftAction("inspect", "showDebugHover", "editor.debug.action.showDebugHover"),
-    MakeshiftAction("pour cell", "editNewCellBelow", "jupyter.insertCellBelow"),
     MakeshiftAction(
         "quick fix", "quickFix", "editor.action.quickFix", pre_command_sleep=0.3
     ),

--- a/src/actions/actions.py
+++ b/src/actions/actions.py
@@ -110,7 +110,9 @@ def run_makeshift_action(action: str, targets: dict):
 
 
 def on_watch():
+# def on_watch(lists: List[dict]):
     print("On watch")
 
 
 app.register("ready", lambda: watch_csv("actions", simple_actions, on_watch))
+# app.register("ready", lambda: watch_csv("actions", [simple_actions, swap_actions], on_watch))

--- a/src/actions/actions.py
+++ b/src/actions/actions.py
@@ -24,7 +24,7 @@ makeshift_actions = [
     MakeshiftAction("hover", "showHover", "editor.action.showHover"),
     MakeshiftAction("inspect", "showDebugHover", "editor.debug.action.showDebugHover"),
     MakeshiftAction(
-        "quick fix", "quickFix", "editor.action.quickFix", pre_command_sleep=0.3
+        "quick fix", "showQuickFix", "editor.action.quickFix", pre_command_sleep=0.3
     ),
     MakeshiftAction("reference", "showReferences", "references-view.find"),
     MakeshiftAction("rename", "rename", "editor.action.rename", post_command_sleep=0.1),
@@ -43,8 +43,8 @@ class CallbackAction:
 # NOTE: Please do not change these dicts.  Use the CSVs for customization.
 # See https://github.com/pokey/cursorless-talon/blob/master/docs/customization.md
 callbacks = [
-    CallbackAction("call", "call", run_call_action),
-    CallbackAction("scout", "find", run_find_action),
+    CallbackAction("call", "callAsFunction", run_call_action),
+    CallbackAction("scout", "findInDocument", run_find_action),
     CallbackAction("phones", "nextHomophone", run_homophones_action),
 ]
 
@@ -58,33 +58,33 @@ mod.list("cursorless_simple_action", desc="Supported actions for cursorless navi
 # See https://github.com/pokey/cursorless-talon/blob/master/docs/customization.md
 simple_actions = {
     "bottom": "scrollToBottom",
-    "breakpoint": "setBreakpoint",
-    "carve": "cut",
+    "breakpoint": "toggleLineBreakpoint",
+    "carve": "cutToClipboard",
     "center": "scrollToCenter",
-    "chuck": "delete",
-    "clear": "clear",
-    "clone up": "copyLinesUp",
-    "clone": "copyLinesDown",
-    "comment": "commentLines",
-    "copy": "copy",
+    "chuck": "remove",
+    "clear": "clearAndSetSelection",
+    "clone up": "insertCopyBefore",
+    "clone": "insertCopyAfter",
+    "comment": "toggleLineComment",
+    "copy": "copyToClipboard",
     "crown": "scrollToTop",
-    "dedent": "outdentLines",
-    "drink": "editNewLineAbove",
-    "drop": "insertEmptyLineAbove",
+    "dedent": "outdentLine",
+    "drink": "editNewLineBefore",
+    "drop": "insertEmptyLineBefore",
     "extract": "extractVariable",
-    "float": "insertEmptyLineBelow",
-    "fold": "fold",
-    "indent": "indentLines",
-    "paste to": "paste",
+    "float": "insertEmptyLineAfter",
+    "fold": "foldRegion",
+    "indent": "indentLine",
+    "paste to": "pasteFromClipboard",
     "post": "setSelectionAfter",
-    "pour": "editNewLineBelow",
+    "pour": "editNewLineAfter",
     "pre": "setSelectionBefore",
     "puff": "insertEmptyLinesAround",
-    "reverse": "reverse",
-    "scout all": "findInFiles",
-    "sort": "sort",
+    "reverse": "reverseTargets",
+    "scout all": "findInWorkspace",
+    "sort": "sortTargets",
     "take": "setSelection",
-    "unfold": "unfold",
+    "unfold": "unfoldRegion",
     **{action.term: action.identifier for action in makeshift_actions},
     **{callback.term: callback.identifier for callback in callbacks},
 }
@@ -115,10 +115,10 @@ def run_makeshift_action(action: str, targets: dict):
 # See https://github.com/pokey/cursorless-talon/blob/master/docs/customization.md
 default_values = {
     "simple_action": simple_actions,
-    "swap_action": {"swap": "swap"},
-    "move_bring_action": {"bring": "bring", "move": "move"},
-    "wrap_action": {"wrap": "wrap"},
-    "reformat_action": {"format": "reformat"},
+    "swap_action": {"swap": "swapTargets"},
+    "move_bring_action": {"bring": "replaceWithTarget", "move": "moveToTarget"},
+    "wrap_action": {"wrap": "wrapWithPairedDelimiter"},
+    "reformat_action": {"format": "applyFormatter"},
 }
 
 ACTION_LIST_NAMES = default_values.keys()

--- a/src/actions/call.py
+++ b/src/actions/call.py
@@ -6,4 +6,4 @@ mod = Module()
 
 def run_call_action(target: dict):
     targets = [target, STRICT_HERE]
-    actions.user.cursorless_multiple_target_command("call", targets)
+    actions.user.cursorless_multiple_target_command("callAsFunction", targets)

--- a/src/actions/move_bring.py
+++ b/src/actions/move_bring.py
@@ -2,12 +2,20 @@ from talon import Module
 from ..primitive_target import STRICT_HERE
 
 mod = Module()
+mod.list(
+    "cursorless_source_destination_connective",
+    desc="The connective used to separate source and destination targets",
+)
 
 
 mod.list("cursorless_move_bring_action", desc="Cursorless move or bring actions")
 
 
-@mod.capture(rule=("<user.cursorless_target> [to <user.cursorless_target>]"))
+@mod.capture(
+    rule=(
+        "<user.cursorless_target> [{user.cursorless_source_destination_connective} <user.cursorless_target>]"
+    )
+)
 def cursorless_move_bring_targets(m) -> str:
     target_list = m.cursorless_target_list
 

--- a/src/actions/move_bring.py
+++ b/src/actions/move_bring.py
@@ -1,16 +1,10 @@
+from talon import Module
 from ..primitive_target import STRICT_HERE
-from talon import Context, Module
 
 mod = Module()
 
-ctx = Context()
-ctx.matches = r"""
-tag: user.cursorless
-"""
-
 
 mod.list("cursorless_move_bring_action", desc="Cursorless move or bring actions")
-ctx.lists["self.cursorless_move_bring_action"] = {"bring", "move"}
 
 
 @mod.capture(rule=("<user.cursorless_target> [to <user.cursorless_target>]"))

--- a/src/actions/reformat.py
+++ b/src/actions/reformat.py
@@ -4,16 +4,15 @@ from .get_text import get_text
 
 mod = Module()
 
+mod.list("cursorless_reformat_action", desc="Cursorless reformat action")
+
 
 @mod.action_class
 class Actions:
     def cursorless_reformat(targets: dict, formatters: str):
         """Reformat targets with formatter"""
         texts = get_text(targets, show_decorations=False)
-        updated_texts = list(map(
-            lambda text: actions.user.reformat_text(text, formatters),
-            texts
-        ))
-        actions.user.cursorless_replace(
-            targets, updated_texts
+        updated_texts = list(
+            map(lambda text: actions.user.reformat_text(text, formatters), texts)
         )
+        actions.user.cursorless_replace(targets, updated_texts)

--- a/src/actions/swap.py
+++ b/src/actions/swap.py
@@ -4,9 +4,17 @@ from ..primitive_target import BASE_TARGET
 mod = Module()
 
 mod.list("cursorless_swap_action", desc="Cursorless swap action")
+mod.list(
+    "cursorless_swap_connective",
+    desc="The connective used to separate swap targets",
+)
 
 
-@mod.capture(rule=("[<user.cursorless_target>] with <user.cursorless_target>"))
+@mod.capture(
+    rule=(
+        "[<user.cursorless_target>] {user.cursorless_swap_connective} <user.cursorless_target>"
+    )
+)
 def cursorless_swap_targets(m) -> str:
     target_list = m.cursorless_target_list
 

--- a/src/actions/swap.py
+++ b/src/actions/swap.py
@@ -1,10 +1,16 @@
-from ..primitive_target import BASE_TARGET
 from talon import Module
+from ..primitive_target import BASE_TARGET
 
 mod = Module()
 
+mod.list("cursorless_swap_action", desc="Cursorless swap action")
 
-@mod.capture(rule=("swap [<user.cursorless_target>] with <user.cursorless_target>"))
+
+@mod.capture(
+    rule=(
+        "{user.cursorless_swap_action} [<user.cursorless_target>] with <user.cursorless_target>"
+    )
+)
 def cursorless_swap(m) -> str:
     target_list = m.cursorless_target_list
 

--- a/src/actions/swap.py
+++ b/src/actions/swap.py
@@ -6,12 +6,8 @@ mod = Module()
 mod.list("cursorless_swap_action", desc="Cursorless swap action")
 
 
-@mod.capture(
-    rule=(
-        "{user.cursorless_swap_action} [<user.cursorless_target>] with <user.cursorless_target>"
-    )
-)
-def cursorless_swap(m) -> str:
+@mod.capture(rule=("[<user.cursorless_target>] with <user.cursorless_target>"))
+def cursorless_swap_targets(m) -> str:
     target_list = m.cursorless_target_list
 
     if len(target_list) == 1:

--- a/src/actions/wrap.py
+++ b/src/actions/wrap.py
@@ -1,8 +1,8 @@
 from ..modifiers.surrounding_pair import paired_delimiters_map
-from talon import Module, Context
+from talon import Module
+
 
 mod = Module()
-ctx = Context()
 
 
 mod.list("cursorless_wrap_action", desc="Cursorless wrap action")

--- a/src/actions/wrap.py
+++ b/src/actions/wrap.py
@@ -1,27 +1,14 @@
+from ..modifiers.surrounding_pair import paired_delimiters_map
 from talon import Module, Context
 
 mod = Module()
 ctx = Context()
 
 
-wrappers = {
-    "square": ["[", "]"],
-    "round": ["(", ")"],
-    "curly": ["{", "}"],
-    "diamond": ["<", ">"],
-    "twin": ["'", "'"],
-    "quad": ['"', '"'],
-    "brick": ["`", "`"],
-    "escaped twin": ["\\'", "\\'"],
-    "escaped quad": ['\\"', '\\"'],
-    "space": [" ", " "],
-}
-
 mod.list("cursorless_wrap_action", desc="Cursorless wrap action")
-mod.list("cursorless_wrapper", desc="Supported wrappers for cursorless wrap action")
-ctx.lists["self.cursorless_wrapper"] = wrappers.keys()
 
 
-@mod.capture(rule=("{user.cursorless_wrapper}"))
+@mod.capture(rule=("{user.cursorless_paired_delimiter}"))
 def cursorless_wrapper(m) -> list[str]:
-    return wrappers[m.cursorless_wrapper]
+    paired_delimiter_info = paired_delimiters_map[m.cursorless_paired_delimiter]
+    return [paired_delimiter_info.left, paired_delimiter_info.right]

--- a/src/actions/wrap.py
+++ b/src/actions/wrap.py
@@ -3,6 +3,7 @@ from talon import Module, Context
 mod = Module()
 ctx = Context()
 
+
 wrappers = {
     "square": ["[", "]"],
     "round": ["(", ")"],
@@ -16,6 +17,7 @@ wrappers = {
     "space": [" ", " "],
 }
 
+mod.list("cursorless_wrap_action", desc="Cursorless wrap action")
 mod.list("cursorless_wrapper", desc="Supported wrappers for cursorless wrap action")
 ctx.lists["self.cursorless_wrapper"] = wrappers.keys()
 

--- a/src/actions/wrap.py
+++ b/src/actions/wrap.py
@@ -1,4 +1,4 @@
-from ..modifiers.surrounding_pair import paired_delimiters_map
+from ..paired_delimiter import paired_delimiters_map
 from talon import Module
 
 

--- a/src/cheat_sheet.py
+++ b/src/cheat_sheet.py
@@ -172,13 +172,20 @@ class CheatSheet:
 
         self.next_column(canvas)
 
+        range_specifiers = get_raw_list("range_specifier")
+        include_both_term = next(
+            spoken_form
+            for spoken_form, value in range_specifiers.items()
+            if value == "includeBoth"
+        )
+
         self.draw_header(canvas, "Compound targets")
         self.draw_items(
             canvas,
             {
-                "T and T": "T1 and T2",
-                "T past T": "T1 past T2",
-                "past T": "S past T",
+                "T1 and T2": "T1 and T2",
+                f"T1 {include_both_term} T2": "T1 through T2",
+                f"{include_both_term} T": "S through T",
             },
         )
 
@@ -347,14 +354,15 @@ def get_list(name, descriptions=None):
     if descriptions is None:
         descriptions = {}
 
-    items = get_raw_list(get_cursorless_list_name(name))
+    items = get_raw_list(name)
     if isinstance(items, dict):
         make_dict_readable(items, descriptions)
     return items
 
 
 def get_raw_list(name):
-    return registry.lists[name][0].copy()
+    cursorless_list_name = get_cursorless_list_name(name)
+    return registry.lists[cursorless_list_name][0].copy()
 
 
 def get_y(canvas):

--- a/src/cheat_sheet.py
+++ b/src/cheat_sheet.py
@@ -160,7 +160,7 @@ class CheatSheet:
 
         self.next_row()
         self.draw_header(canvas, "Subtokens")
-        self.draw_items(canvas, get_list("subtoken"))
+        self.draw_items(canvas, get_list("subtoken_scope_type"))
 
         self.next_row()
         self.draw_header(canvas, "Positions")

--- a/src/cheat_sheet.py
+++ b/src/cheat_sheet.py
@@ -106,9 +106,9 @@ class CheatSheet:
             if key not in multiple_target_action_names
         }
         complex_actions = {
-            key: value
+            value: key
             for key, value in all_actions.items()
-            if key in multiple_target_action_names
+            if value in multiple_target_action_names
         }
 
         make_dict_readable(
@@ -168,13 +168,7 @@ class CheatSheet:
 
         self.next_row()
         self.draw_header(canvas, "Special marks")
-        self.draw_items(
-            canvas,
-            get_list(
-                "special_mark",
-                {"this": "Selection", "that": "Last T", "source": "Source T"},
-            ),
-        )
+        self.draw_items(canvas, get_list("special_mark"))
 
         self.next_column(canvas)
 

--- a/src/cheat_sheet.py
+++ b/src/cheat_sheet.py
@@ -97,10 +97,6 @@ class CheatSheet:
             "simple_action",
             {
                 "call": "Call T on S",
-                "define": "Reveal definition",
-                "drink cell": "Edit new cell above",
-                "pour cell": "Edit new cell below",
-                "reference": "Show references",
             },
         )
 

--- a/src/cheat_sheet.py
+++ b/src/cheat_sheet.py
@@ -174,20 +174,20 @@ class CheatSheet:
 
         include_both_term = next(
             spoken_form
-            for spoken_form, value in get_raw_list("range_specifier").items()
+            for spoken_form, value in get_raw_list("range_connective").items()
             if value == "rangeIncludingBothEnds"
         )
-        list_specifier_term = next(
+        list_connective_term = next(
             spoken_form
-            for spoken_form, value in get_raw_list("list_specifier").items()
-            if value == "listSpecifier"
+            for spoken_form, value in get_raw_list("list_connective").items()
+            if value == "listConnective"
         )
 
         self.draw_header(canvas, "Compound targets")
         self.draw_items(
             canvas,
             {
-                f"T1 {list_specifier_term} T2": "T1 and T2",
+                f"T1 {list_connective_term} T2": "T1 and T2",
                 f"T1 {include_both_term} T2": "T1 through T2",
                 f"{include_both_term} T": "S through T",
             },

--- a/src/cheat_sheet.py
+++ b/src/cheat_sheet.py
@@ -1,3 +1,4 @@
+from .conventions import get_cursorless_list_name
 from talon import Module, ui, registry, skia, actions, cron
 from talon.canvas import Canvas
 import re
@@ -338,7 +339,7 @@ class Actions:
 
 
 def get_list(name, descriptions={}):
-    items = get_raw_list(f"user.cursorless_{name}")
+    items = get_raw_list(get_cursorless_list_name(name))
     if isinstance(items, dict):
         make_dict_readable(items, descriptions)
     return items

--- a/src/cheat_sheet.py
+++ b/src/cheat_sheet.py
@@ -99,11 +99,16 @@ class CheatSheet:
         for name in ACTION_LIST_NAMES:
             all_actions.update(get_raw_list(name))
 
-        multiple_target_action_names = ["bring", "move", "swap", "reformat"]
+        multiple_target_action_names = [
+            "replaceWithTarget",
+            "moveToTarget",
+            "swapTargets",
+            "applyFormatter",
+        ]
         simple_actions = {
             key: value
             for key, value in all_actions.items()
-            if key not in multiple_target_action_names
+            if value not in multiple_target_action_names
         }
         complex_actions = {
             value: key
@@ -112,21 +117,23 @@ class CheatSheet:
         }
 
         make_dict_readable(
-            all_actions,
+            simple_actions,
             {
-                "call": "Call T on S",
-                "wrap": '"round" wrap T',
+                "callAsFunction": "Call T on S",
+                "wrapWithPairedDelimiter": '"round" wrap T',
             },
         )
         all_actions = {
             **simple_actions,
-            "{0} T1 to T2".format(complex_actions["bring"]): "Replace T2 with T1",
-            "{0} T".format(complex_actions["bring"]): "Replace S with T",
-            "{0} T1 to T2".format(complex_actions["move"]): "Move T1 to T2",
-            "{0} T".format(complex_actions["move"]): "Move T to S",
-            "{0} T1 to T2".format(complex_actions["swap"]): "Swap T1 with T2",
-            "{0} T".format(complex_actions["swap"]): "Swap S with T",
-            "{0} * at T".format(complex_actions["reformat"]): "Reformat T as *",
+            "{0} T1 to T2".format(
+                complex_actions["replaceWithTarget"]
+            ): "Replace T2 with T1",
+            "{0} T".format(complex_actions["replaceWithTarget"]): "Replace S with T",
+            "{0} T1 to T2".format(complex_actions["moveToTarget"]): "Move T1 to T2",
+            "{0} T".format(complex_actions["moveToTarget"]): "Move T to S",
+            "{0} T1 to T2".format(complex_actions["swapTargets"]): "Swap T1 with T2",
+            "{0} T".format(complex_actions["swapTargets"]): "Swap S with T",
+            "{0} * at T".format(complex_actions["applyFormatter"]): "Reformat T as *",
         }
 
         actions_limit = round(len(all_actions) / 2)
@@ -141,7 +148,7 @@ class CheatSheet:
         self.draw_items(canvas, actions_2)
         self.next_column(canvas)
 
-        all_scopes = get_list("scope_type")
+        all_scopes = get_list("scope_type", {"argumentOrParameter": "Argument"})
         scopes_limit = len(all_scopes) - 3
         scopes_1 = slice_dict(all_scopes, 0, scopes_limit)
         scopes_2 = slice_dict(all_scopes, scopes_limit)

--- a/src/cheat_sheet.py
+++ b/src/cheat_sheet.py
@@ -205,7 +205,11 @@ class CheatSheet:
 
         self.next_row()
         self.draw_header(canvas, "Colors")
-        self.draw_items(canvas, get_list("symbol_color"))
+        self.draw_items(canvas, get_list("hat_color"))
+
+        self.next_row()
+        self.draw_header(canvas, "Shapes")
+        self.draw_items(canvas, get_list("hat_shape"))
 
         self.next_row()
         self.draw_header(canvas, "Examples")

--- a/src/cheat_sheet.py
+++ b/src/cheat_sheet.py
@@ -116,6 +116,11 @@ class CheatSheet:
             if value in multiple_target_action_names
         }
 
+        swap_connective = list(get_raw_list("swap_connective").keys())[0]
+        source_destination_connective = list(
+            get_raw_list("source_destination_connective").keys()
+        )[0]
+
         make_dict_readable(
             simple_actions,
             {
@@ -125,15 +130,13 @@ class CheatSheet:
         )
         all_actions = {
             **simple_actions,
-            "{0} T1 to T2".format(
-                complex_actions["replaceWithTarget"]
-            ): "Replace T2 with T1",
-            "{0} T".format(complex_actions["replaceWithTarget"]): "Replace S with T",
-            "{0} T1 to T2".format(complex_actions["moveToTarget"]): "Move T1 to T2",
-            "{0} T".format(complex_actions["moveToTarget"]): "Move T to S",
-            "{0} T1 to T2".format(complex_actions["swapTargets"]): "Swap T1 with T2",
-            "{0} T".format(complex_actions["swapTargets"]): "Swap S with T",
-            "{0} * at T".format(complex_actions["applyFormatter"]): "Reformat T as *",
+            f"{complex_actions['replaceWithTarget']} T1 {source_destination_connective} T2": "Replace T2 with T1",
+            f"{complex_actions['replaceWithTarget']} T": "Replace S with T",
+            f"{complex_actions['moveToTarget']} T1 {source_destination_connective} T2": "Move T1 to T2",
+            f"{complex_actions['moveToTarget']} T": "Move T to S",
+            f"{complex_actions['swapTargets']} T1 {swap_connective} T2": "Swap T1 with T2",
+            f"{complex_actions['swapTargets']} T": "Swap S with T",
+            f"{complex_actions['applyFormatter']} * at T": "Reformat T as *",
         }
 
         actions_limit = round(len(all_actions) / 2)

--- a/src/cheat_sheet.py
+++ b/src/cheat_sheet.py
@@ -180,7 +180,7 @@ class CheatSheet:
         list_specifier_term = next(
             spoken_form
             for spoken_form, value in get_raw_list("list_specifier").items()
-            if value == "list"
+            if value == "listSpecifier"
         )
 
         self.draw_header(canvas, "Compound targets")

--- a/src/cheat_sheet.py
+++ b/src/cheat_sheet.py
@@ -175,7 +175,7 @@ class CheatSheet:
         include_both_term = next(
             spoken_form
             for spoken_form, value in get_raw_list("range_connective").items()
-            if value == "rangeIncludingBothEnds"
+            if value == "rangeInclusive"
         )
         list_connective_term = next(
             spoken_form

--- a/src/cheat_sheet.py
+++ b/src/cheat_sheet.py
@@ -172,18 +172,22 @@ class CheatSheet:
 
         self.next_column(canvas)
 
-        range_specifiers = get_raw_list("range_specifier")
         include_both_term = next(
             spoken_form
-            for spoken_form, value in range_specifiers.items()
-            if value == "includeBoth"
+            for spoken_form, value in get_raw_list("range_specifier").items()
+            if value == "rangeIncludingBothEnds"
+        )
+        list_specifier_term = next(
+            spoken_form
+            for spoken_form, value in get_raw_list("list_specifier").items()
+            if value == "list"
         )
 
         self.draw_header(canvas, "Compound targets")
         self.draw_items(
             canvas,
             {
-                "T1 and T2": "T1 and T2",
+                f"T1 {list_specifier_term} T2": "T1 and T2",
                 f"T1 {include_both_term} T2": "T1 through T2",
                 f"{include_both_term} T": "S through T",
             },

--- a/src/cheat_sheet.py
+++ b/src/cheat_sheet.py
@@ -99,7 +99,18 @@ class CheatSheet:
         for name in ACTION_LIST_NAMES:
             all_actions.update(get_raw_list(name))
 
-        keys = dict_remove_values(all_actions, "bring", "move", "swap", "reformat")
+        multiple_target_action_names = ["bring", "move", "swap", "reformat"]
+        simple_actions = {
+            key: value
+            for key, value in all_actions.items()
+            if key not in multiple_target_action_names
+        }
+        complex_actions = {
+            key: value
+            for key, value in all_actions.items()
+            if key in multiple_target_action_names
+        }
+
         make_dict_readable(
             all_actions,
             {
@@ -108,14 +119,14 @@ class CheatSheet:
             },
         )
         all_actions = {
-            **all_actions,
-            "{0} T1 to T2".format(keys["bring"]): "Replace T2 with T1",
-            "{0} T".format(keys["bring"]): "Replace S with T",
-            "{0} T1 to T2".format(keys["move"]): "Move T1 to T2",
-            "{0} T".format(keys["move"]): "Move T to S",
-            "{0} T1 to T2".format(keys["swap"]): "Swap T1 with T2",
-            "{0} T".format(keys["swap"]): "Swap S with T",
-            "{0} * at T".format(keys["reformat"]): "Reformat T as *",
+            **simple_actions,
+            "{0} T1 to T2".format(complex_actions["bring"]): "Replace T2 with T1",
+            "{0} T".format(complex_actions["bring"]): "Replace S with T",
+            "{0} T1 to T2".format(complex_actions["move"]): "Move T1 to T2",
+            "{0} T".format(complex_actions["move"]): "Move T to S",
+            "{0} T1 to T2".format(complex_actions["swap"]): "Swap T1 with T2",
+            "{0} T".format(complex_actions["swap"]): "Swap S with T",
+            "{0} * at T".format(complex_actions["reformat"]): "Reformat T as *",
         }
 
         actions_limit = round(len(all_actions) / 2)
@@ -131,7 +142,7 @@ class CheatSheet:
         self.next_column(canvas)
 
         all_scopes = get_list("scope_type")
-        scopes_limit = round(len(all_scopes) - 3)
+        scopes_limit = len(all_scopes) - 3
         scopes_1 = slice_dict(all_scopes, 0, scopes_limit)
         scopes_2 = slice_dict(all_scopes, scopes_limit)
 
@@ -338,7 +349,10 @@ class Actions:
         webbrowser.open(instructions_url)
 
 
-def get_list(name, descriptions={}):
+def get_list(name, descriptions=None):
+    if descriptions is None:
+        descriptions = {}
+
     items = get_raw_list(get_cursorless_list_name(name))
     if isinstance(items, dict):
         make_dict_readable(items, descriptions)
@@ -357,7 +371,10 @@ def draw_text(canvas, text, x, y):
     canvas.draw_text(text, x, y + text_size + padding / 2)
 
 
-def make_dict_readable(dict, descriptions={}):
+def make_dict_readable(dict, descriptions=None):
+    if descriptions is None:
+        descriptions = {}
+
     for k in dict:
         desc = dict[k]
         if desc in descriptions:
@@ -398,13 +415,3 @@ def is_in_rect(canvas, mouse_pos, rect):
 def slice_dict(dict: dict, start: int, end: int = None):
     keys = sorted(dict)[start:end]
     return {key: dict[key] for key in keys}
-
-
-def dict_remove_values(dict: dict, *values: list):
-    keys = {}
-    for key, value in dict.copy().items():
-        if value in values:
-            del dict[key]
-            keys[value] = key
-    assert len(values) == len(keys)
-    return keys

--- a/src/compound_targets.py
+++ b/src/compound_targets.py
@@ -68,7 +68,7 @@ def on_ready():
         "compound_targets",
         {
             "range_specifier": range_specifiers,
-            "list_specifier": {"and": "list"},
+            "list_specifier": {"and": "listSpecifier"},
         },
     )
 

--- a/src/compound_targets.py
+++ b/src/compound_targets.py
@@ -6,26 +6,26 @@ mod = Module()
 
 
 mod.list(
-    "cursorless_range_specifier",
+    "cursorless_range_connective",
     desc="A range joiner that indicates whether to include or exclude anchor and active",
 )
 mod.list(
-    "cursorless_list_specifier",
+    "cursorless_list_connective",
     desc="A list joiner",
 )
 
 
 @mod.capture(
     rule=(
-        "[{user.cursorless_range_specifier}] <user.cursorless_primitive_target> | "
-        "<user.cursorless_primitive_target> {user.cursorless_range_specifier} <user.cursorless_primitive_target>"
+        "[{user.cursorless_range_connective}] <user.cursorless_primitive_target> | "
+        "<user.cursorless_primitive_target> {user.cursorless_range_connective} <user.cursorless_primitive_target>"
     )
 )
 def cursorless_range(m) -> str:
     primitive_targets = m.cursorless_primitive_target_list
-    range_specifier = getattr(m, "cursorless_range_specifier", None)
+    range_connective = getattr(m, "cursorless_range_connective", None)
 
-    if range_specifier is None:
+    if range_connective is None:
         return primitive_targets[0]
 
     if len(primitive_targets) == 1:
@@ -37,15 +37,15 @@ def cursorless_range(m) -> str:
         "type": "range",
         "start": start,
         "end": primitive_targets[-1],
-        "excludeStart": range_specifier
+        "excludeStart": range_connective
         in ["rangeExcludingBothEnds", "rangeExcludingAnchor"],
-        "excludeEnd": range_specifier
+        "excludeEnd": range_connective
         in ["rangeExcludingBothEnds", "rangeExcludingActive"],
     }
 
 
 @mod.capture(
-    rule="<user.cursorless_range> ({user.cursorless_list_specifier} <user.cursorless_range>)*"
+    rule="<user.cursorless_range> ({user.cursorless_list_connective} <user.cursorless_range>)*"
 )
 def cursorless_target(m) -> str:
     if len(m.cursorless_range_list) == 1:
@@ -55,7 +55,7 @@ def cursorless_target(m) -> str:
 
 # NOTE: Please do not change these dicts.  Use the CSVs for customization.
 # See https://github.com/pokey/cursorless-talon/blob/master/docs/customization.md
-range_specifiers = {
+range_connectives = {
     "between": "rangeExcludingBothEnds",
     "past": "rangeIncludingBothEnds",
     "skip past": "rangeExcludingAnchor",
@@ -67,8 +67,8 @@ def on_ready():
     init_csv_and_watch_changes(
         "compound_targets",
         {
-            "range_specifier": range_specifiers,
-            "list_specifier": {"and": "listSpecifier"},
+            "range_connective": range_connectives,
+            "list_connective": {"and": "listConnective"},
         },
     )
 

--- a/src/compound_targets.py
+++ b/src/compound_targets.py
@@ -43,11 +43,11 @@ def cursorless_range(m) -> str:
 
 
 def is_anchor_included(range_connective: str):
-    return range_connective not in ["rangeExcludingBothEnds", "rangeExcludingAnchor"]
+    return range_connective not in ["rangeExclusive", "rangeExcludingStart"]
 
 
 def is_active_included(range_connective: str):
-    return range_connective not in ["rangeExcludingBothEnds", "rangeExcludingActive"]
+    return range_connective not in ["rangeExclusive", "rangeExcludingEnd"]
 
 
 @mod.capture(
@@ -62,10 +62,10 @@ def cursorless_target(m) -> str:
 # NOTE: Please do not change these dicts.  Use the CSVs for customization.
 # See https://github.com/pokey/cursorless-talon/blob/master/docs/customization.md
 range_connectives = {
-    "between": "rangeExcludingBothEnds",
-    "past": "rangeIncludingBothEnds",
-    "-": "rangeExcludingAnchor",
-    "until": "rangeExcludingActive",
+    "between": "rangeExclusive",
+    "past": "rangeInclusive",
+    "-": "rangeExcludingStart",
+    "until": "rangeExcludingEnd",
 }
 
 

--- a/src/compound_targets.py
+++ b/src/compound_targets.py
@@ -4,10 +4,6 @@ from talon import Module, Context
 mod = Module()
 ctx = Context()
 
-ctx.matches = r"""
-tag: user.cursorless
-"""
-
 range_specifier = {
     "past",
     "until",

--- a/src/compound_targets.py
+++ b/src/compound_targets.py
@@ -53,6 +53,8 @@ def cursorless_target(m) -> str:
     return {"type": "list", "elements": m.cursorless_range_list}
 
 
+# NOTE: Please do not change these dicts.  Use the CSVs for customization.
+# See https://github.com/pokey/cursorless-talon/blob/master/docs/customization.md
 range_specifiers = {
     "between": "rangeExcludingBothEnds",
     "past": "rangeIncludingBothEnds",

--- a/src/compound_targets.py
+++ b/src/compound_targets.py
@@ -64,7 +64,7 @@ def cursorless_target(m) -> str:
 range_connectives = {
     "between": "rangeExcludingBothEnds",
     "past": "rangeIncludingBothEnds",
-    "skip past": "rangeExcludingAnchor",
+    "-": "rangeExcludingAnchor",
     "until": "rangeExcludingActive",
 }
 

--- a/src/compound_targets.py
+++ b/src/compound_targets.py
@@ -9,6 +9,10 @@ mod.list(
     "cursorless_range_specifier",
     desc="A range joiner that indicates whether to include or exclude anchor and active",
 )
+mod.list(
+    "cursorless_list_specifier",
+    desc="A list joiner",
+)
 
 
 @mod.capture(
@@ -33,12 +37,16 @@ def cursorless_range(m) -> str:
         "type": "range",
         "start": start,
         "end": primitive_targets[-1],
-        "excludeStart": range_specifier in ["excludeBoth", "excludeAnchor"],
-        "excludeEnd": range_specifier in ["excludeBoth", "excludeActive"],
+        "excludeStart": range_specifier
+        in ["rangeExcludingBothEnds", "rangeExcludingAnchor"],
+        "excludeEnd": range_specifier
+        in ["rangeExcludingBothEnds", "rangeExcludingActive"],
     }
 
 
-@mod.capture(rule="<user.cursorless_range> (and <user.cursorless_range>)*")
+@mod.capture(
+    rule="<user.cursorless_range> ({user.cursorless_list_specifier} <user.cursorless_range>)*"
+)
 def cursorless_target(m) -> str:
     if len(m.cursorless_range_list) == 1:
         return m.cursorless_range
@@ -46,18 +54,19 @@ def cursorless_target(m) -> str:
 
 
 range_specifiers = {
-    "between": "excludeBoth",
-    "past": "includeBoth",
-    "skip past": "excludeAnchor",
-    "until": "excludeActive",
+    "between": "rangeExcludingBothEnds",
+    "past": "rangeIncludingBothEnds",
+    "skip past": "rangeExcludingAnchor",
+    "until": "rangeExcludingActive",
 }
 
 
 def on_ready():
     init_csv_and_watch_changes(
-        "range_specifiers",
+        "compound_targets",
         {
             "range_specifier": range_specifiers,
+            "list_specifier": {"and": "list"},
         },
     )
 

--- a/src/compound_targets.py
+++ b/src/compound_targets.py
@@ -37,11 +37,17 @@ def cursorless_range(m) -> str:
         "type": "range",
         "start": start,
         "end": primitive_targets[-1],
-        "excludeStart": range_connective
-        in ["rangeExcludingBothEnds", "rangeExcludingAnchor"],
-        "excludeEnd": range_connective
-        in ["rangeExcludingBothEnds", "rangeExcludingActive"],
+        "excludeStart": not is_anchor_included(range_connective),
+        "excludeEnd": not is_active_included(range_connective),
     }
+
+
+def is_anchor_included(range_connective: str):
+    return range_connective not in ["rangeExcludingBothEnds", "rangeExcludingAnchor"]
+
+
+def is_active_included(range_connective: str):
+    return range_connective not in ["rangeExcludingBothEnds", "rangeExcludingActive"]
 
 
 @mod.capture(

--- a/src/compound_targets.py
+++ b/src/compound_targets.py
@@ -1,6 +1,5 @@
 from .primitive_target import BASE_TARGET
-from talon import Module, app
-from .csv_overrides import init_csv_and_watch_changes
+from talon import Module
 
 mod = Module()
 
@@ -57,26 +56,3 @@ def cursorless_target(m) -> str:
     if len(m.cursorless_range_list) == 1:
         return m.cursorless_range
     return {"type": "list", "elements": m.cursorless_range_list}
-
-
-# NOTE: Please do not change these dicts.  Use the CSVs for customization.
-# See https://github.com/pokey/cursorless-talon/blob/master/docs/customization.md
-range_connectives = {
-    "between": "rangeExclusive",
-    "past": "rangeInclusive",
-    "-": "rangeExcludingStart",
-    "until": "rangeExcludingEnd",
-}
-
-
-def on_ready():
-    init_csv_and_watch_changes(
-        "compound_targets",
-        {
-            "range_connective": range_connectives,
-            "list_connective": {"and": "listConnective"},
-        },
-    )
-
-
-app.register("ready", on_ready)

--- a/src/connective.py
+++ b/src/connective.py
@@ -1,0 +1,26 @@
+from talon import app
+from .csv_overrides import init_csv_and_watch_changes
+
+# NOTE: Please do not change these dicts.  Use the CSVs for customization.
+# See https://github.com/pokey/cursorless-talon/blob/master/docs/customization.md
+range_connectives = {
+    "between": "rangeExclusive",
+    "past": "rangeInclusive",
+    "-": "rangeExcludingStart",
+    "until": "rangeExcludingEnd",
+}
+
+
+def on_ready():
+    init_csv_and_watch_changes(
+        "target_connectives",
+        {
+            "range_connective": range_connectives,
+            "list_connective": {"and": "listConnective"},
+            "swap_connective": {"swap": "swapConnective"},
+            "source_destination_connective": {"to": "sourceDestinationConnective"},
+        },
+    )
+
+
+app.register("ready", on_ready)

--- a/src/connective.py
+++ b/src/connective.py
@@ -17,7 +17,7 @@ def on_ready():
         {
             "range_connective": range_connectives,
             "list_connective": {"and": "listConnective"},
-            "swap_connective": {"swap": "swapConnective"},
+            "swap_connective": {"with": "swapConnective"},
             "source_destination_connective": {"to": "sourceDestinationConnective"},
         },
     )

--- a/src/conventions.py
+++ b/src/conventions.py
@@ -1,0 +1,2 @@
+def get_cursorless_list_name(name: str):
+    return f"user.cursorless_{name}"

--- a/src/csv_overrides.py
+++ b/src/csv_overrides.py
@@ -125,11 +125,6 @@ def create_line(key: str, value: str):
     return f"{key}, {value}\n"
 
 
-def read_line(line: str, path, index: int):
-
-    return key, value
-
-
 def get_file_paths(filename: str):
     if not filename.endswith(".csv"):
         filename = f"{filename}.csv"

--- a/src/csv_overrides.py
+++ b/src/csv_overrides.py
@@ -31,16 +31,18 @@ def init_csv_and_watch_changes(
 
 
 def update_dicts(default_values: list[dict], current_values: dict, callback: callable):
+    # Create map with all default values
     results_map = {}
     for i in range(len(default_values)):
         for key, value in default_values[i].items():
             results_map[value] = {"key": key, "value": value, "index": i}
 
+    # Update result with current values
     for key, value in current_values.items():
         results_map[value]["key"] = key
 
+    # Convert result map back to result list
     results = [{} for _ in default_values]
-
     for obj in results_map.values():
         results[obj["index"]][obj["key"]] = obj["value"]
 

--- a/src/csv_overrides.py
+++ b/src/csv_overrides.py
@@ -1,62 +1,54 @@
-from talon import actions, fs, app
+from talon import Context, actions, fs, app
 import os
 from datetime import datetime
 from pathlib import Path
-from .util import flat_dicts
 
 directory_name = "cursorless-settings"
 
+ctx = Context()
 
-def init_csv_and_watch_changes(
-    filename: str, default_values: dict or list[dict], callback: callable
-):
-    is_list = isinstance(default_values, list)
-    if not is_list:
-        default_values = [default_values]
+
+def init_csv_and_watch_changes(filename: str, default_values: dict[str, dict]):
     dir_path, file_path = get_file_paths(filename)
-    super_default_values = flat_dicts(default_values)
+    super_default_values = get_super_values(default_values)
 
     if not dir_path.is_dir():
         os.mkdir(dir_path)
 
-    def inner_callback(updated_dicts: list[dict]):
-        if is_list:
-            callback(updated_dicts)
-        else:
-            callback(updated_dicts[0])
-
     def on_watch(path, flags):
         if file_path.match(path):
             current_values = read_file(file_path, super_default_values.values())
-            update_dicts(default_values, current_values, inner_callback)
+            update_dicts(default_values, current_values)
 
     fs.watch(dir_path, on_watch)
 
     if file_path.is_file():
         current_values = update_file(file_path, super_default_values)
-        update_dicts(default_values, current_values, inner_callback)
+        update_dicts(default_values, current_values)
     else:
         create_file(file_path, super_default_values)
-        update_dicts(default_values, super_default_values, inner_callback)
+        update_dicts(default_values, super_default_values)
 
 
-def update_dicts(default_values: list[dict], current_values: dict, callback: callable):
+def update_dicts(default_values: dict[str, dict], current_values: dict):
     # Create map with all default values
     results_map = {}
-    for i in range(len(default_values)):
-        for key, value in default_values[i].items():
-            results_map[value] = {"key": key, "value": value, "index": i}
+    for list_name, dict in default_values.items():
+        for key, value in dict.items():
+            results_map[value] = {"key": key, "value": value, "list": list_name}
 
     # Update result with current values
     for key, value in current_values.items():
         results_map[value]["key"] = key
 
     # Convert result map back to result list
-    results = [{} for _ in default_values]
+    results = {key: {} for key in default_values}
     for obj in results_map.values():
-        results[obj["index"]][obj["key"]] = obj["value"]
+        results[obj["list"]][obj["key"]] = obj["value"]
 
-    callback(results)
+    # Assign result to talon context list
+    for list_name, dict in results.items():
+        ctx.lists[f"user.cursorless_{list_name}"] = dict
 
 
 def update_file(path, default_values: dict):
@@ -102,14 +94,31 @@ def read_file(path, default_identifiers: list[str]) -> dict:
         lines = f.read().splitlines()
 
     result = {}
+    used_identifiers = []
     for i in range(len(lines)):
         line = lines[i].strip()
         if len(line) == 0 or line.startswith("#"):
             continue
-        key, value = read_line(line, path, i)
-        assert value in default_identifiers, f"Unknown identifier {value}"
+
+        parts = line.split(",")
+        assert len(parts) == 2, error_message(path, i, "Malformed csv", value)
+        key = parts[0].strip()
+        value = parts[1].strip()
+
+        assert value in default_identifiers, error_message(
+            path, i, "Unknown identifier", value
+        )
+        assert value not in used_identifiers, error_message(
+            path, i, "Duplicate identifier", value
+        )
+
         result[key] = value
+        used_identifiers.append(value)
     return result
+
+
+def error_message(path, index, message, value):
+    return f"{path.name}:{index+1} | {message} | {value}"
 
 
 def create_line(key: str, value: str):
@@ -117,10 +126,7 @@ def create_line(key: str, value: str):
 
 
 def read_line(line: str, path, index: int):
-    parts = line.split(",")
-    assert len(parts) == 2, f"Malformed {path.name}:{index+1} | {line}"
-    key = parts[0].strip()
-    value = parts[1].strip()
+
     return key, value
 
 
@@ -131,3 +137,10 @@ def get_file_paths(filename: str):
     dir_path = Path(user_dir, directory_name)
     csv_path = Path(dir_path, filename)
     return dir_path, csv_path
+
+
+def get_super_values(values: dict[str, dict]):
+    result = {}
+    for dict in values.values():
+        result.update(dict)
+    return result

--- a/src/csv_overrides.py
+++ b/src/csv_overrides.py
@@ -23,7 +23,7 @@ def get_file_path(filename: str) -> str:
 def watch_csv(filename: str, default_values: dict, callback: callable):
     dir_path, file_path = get_file_path(filename)
     print(file_path)
-    print(default_values)
+    # print(default_values)
 
     if not dir_path.is_dir():
         os.mkdir(dir_path)
@@ -34,7 +34,8 @@ def watch_csv(filename: str, default_values: dict, callback: callable):
     else:
         create_file(file_path, default_values)
 
-    # fs.watch(file_path, callback)
+    on_watch = lambda path, flags: callback()
+    fs.watch(file_path, on_watch)
 
 
 def update_file(path, default_values: dict):
@@ -50,12 +51,6 @@ def create_file(path, default_values: dict):
     fo.writelines(lines)
     fo.close()
 
-
-def on_ready():
-    print("On ready")
-
-
-# app.register("ready", on_ready)
 
 # NOTE: This method requires this module to be one folder below the top-level
 #   knausj folder.

--- a/src/csv_overrides.py
+++ b/src/csv_overrides.py
@@ -76,11 +76,14 @@ def update_file(path: Path, default_values: dict):
             ]
             write_file(path, lines, "a")
 
-            message = f"🎉🎉 New cursorless features in {path.name}"
-            print(message)
+            print(f"New cursorless features added to {path.name}")
             for key in sorted(missing):
                 print(f"{key}: {missing[key]}")
-            app.notify(message)
+            print(
+                "See release notes for more info: "
+                "https://github.com/pokey/cursorless-vscode/blob/master/CHANGELOG.md"
+            )
+            app.notify(f"🎉🎉 New cursorless features; see log")
 
     return current_values
 

--- a/src/csv_overrides.py
+++ b/src/csv_overrides.py
@@ -101,9 +101,7 @@ def csv_error(path: Path, index: int, message: str, value: str):
         index (int): The index into the file (for error reporting)
         text (str): The text of the error message to report if condition is false
     """
-    error_message = f"ERROR: {path}:{index+1}: {message} '{value}'"
-    app.notify("Cursorless settings error; see log")
-    print(error_message)
+    print(f"ERROR: {path}:{index+1}: {message} '{value}'")
 
 
 def read_file(path: Path, default_identifiers: list[str]):
@@ -137,6 +135,9 @@ def read_file(path: Path, default_identifiers: list[str]):
 
         result[key] = value
         used_identifiers.append(value)
+
+    if has_errors:
+        app.notify("Cursorless settings error; see log")
 
     return result, has_errors
 

--- a/src/csv_overrides.py
+++ b/src/csv_overrides.py
@@ -2,6 +2,7 @@ from talon import actions, fs, app
 import os
 from datetime import datetime
 from pathlib import Path
+from .util import flat_dicts
 
 directory_name = "cursorless-settings"
 
@@ -10,7 +11,7 @@ def init_csv_and_watch_changes(
     filename: str, default_values: list[dict], callback: callable
 ):
     dir_path, file_path = get_file_paths(filename)
-    super_default_values = join_dicts(default_values)
+    super_default_values = flat_dicts(default_values)
 
     if not dir_path.is_dir():
         os.mkdir(dir_path)
@@ -112,13 +113,6 @@ def read_line(line: str, path, index: int):
     key = parts[0].strip()
     value = parts[1].strip()
     return key, value
-
-
-def join_dicts(dicts: list[dict]):
-    result = {}
-    for dict in dicts:
-        result.update(dict)
-    return result
 
 
 def get_file_paths(filename: str):

--- a/src/csv_overrides.py
+++ b/src/csv_overrides.py
@@ -25,6 +25,9 @@ def init_csv_and_watch_changes(filename: str, default_values: dict[str, dict]):
 
         actions.path.talon_user() / "cursorless-settings" / filename
 
+    Note that the settings directory location can be customized using the
+    `user.cursorless_settings_directory` setting.
+
     Args:
         filename (str): The name of the csv file to be placed in
         `cursorles-settings` dir

--- a/src/csv_overrides.py
+++ b/src/csv_overrides.py
@@ -72,10 +72,9 @@ def update_dicts(default_values: dict[str, dict], current_values: dict):
     results = {key: {} for key in default_values}
     for obj in results_map.values():
         value = obj["value"]
-        if is_removed(value):
-            del results[obj["list"]][obj["key"]]
-        else:
-            results[obj["list"]][obj["key"]] = value
+        key = obj["key"]
+        if not is_removed(key):
+            results[obj["list"]][key] = value
 
     # Assign result to talon context list
     for list_name, dict in results.items():

--- a/src/csv_overrides.py
+++ b/src/csv_overrides.py
@@ -1,0 +1,113 @@
+from talon import actions, fs, app
+import csv
+import os
+from pathlib import Path
+from typing import Dict, List, Tuple
+from talon import resource
+
+directory_name = "cursorless-settings"
+
+# def update_lists_from_csv(filename: str, *args: [dict]):
+# print()
+
+
+def get_file_path(filename: str) -> str:
+    if not filename.endswith(".csv"):
+        filename = f"{filename}.csv"
+    user_dir = actions.path.talon_user()
+    dir_path = Path(user_dir, directory_name)
+    csv_path = Path(dir_path, filename)
+    return dir_path, csv_path
+
+
+def watch_csv(filename: str, default_values: dict, callback: callable):
+    dir_path, file_path = get_file_path(filename)
+    print(file_path)
+    print(default_values)
+
+    if not dir_path.is_dir():
+        os.mkdir(dir_path)
+
+    if file_path.is_file():
+        update_file(file_path, default_values)
+        # callback()
+    else:
+        create_file(file_path, default_values)
+
+    # fs.watch(file_path, callback)
+
+
+def update_file(path, default_values: dict):
+    print("update file")
+
+
+def create_file(path, default_values: dict):
+    print("create file")
+    lines = [f"{key},{default_values[key]}\n" for key in sorted(default_values)]
+    lines.insert(0, "# Spoken words,Identifier\n")
+    print(lines)
+    fo = open(path, "w")
+    fo.writelines(lines)
+    fo.close()
+
+
+def on_ready():
+    print("On ready")
+
+
+# app.register("ready", on_ready)
+
+# NOTE: This method requires this module to be one folder below the top-level
+#   knausj folder.
+# SETTINGS_DIR = Path(__file__).parents[1] / "settings"
+
+# if not SETTINGS_DIR.is_dir():
+#     os.mkdir(SETTINGS_DIR)
+
+
+# def get_list_from_csv(
+#     filename: str, headers: Tuple[str, str], default: Dict[str, str] = {}
+# ):
+#     """Retrieves list from CSV"""
+#     path = SETTINGS_DIR / filename
+#     assert filename.endswith(".csv")
+
+#     if not path.is_file():
+#         with open(path, "w", encoding="utf-8") as file:
+#             writer = csv.writer(file)
+#             writer.writerow(headers)
+#             for key, value in default.items():
+#                 writer.writerow([key] if key == value else [value, key])
+
+#     # Now read via resource to take advantage of talon's
+#     # ability to reload this script for us when the resource changes
+#     with resource.open(str(path), "r") as f:
+#         rows = list(csv.reader(f))
+
+#     # print(str(rows))
+#     mapping = {}
+#     if len(rows) >= 2:
+#         actual_headers = rows[0]
+#         if not actual_headers == list(headers):
+#             print(
+#                 f'"{filename}": Malformed headers - {actual_headers}.'
+#                 + f" Should be {list(headers)}. Ignoring row."
+#             )
+#         for row in rows[1:]:
+#             if len(row) == 0:
+#                 # Windows newlines are sometimes read as empty rows. :champagne:
+#                 continue
+#             if len(row) == 1:
+#                 output = spoken_form = row[0]
+#             else:
+#                 output, spoken_form = row[:2]
+#                 if len(row) > 2:
+#                     print(
+#                         f'"{filename}": More than two values in row: {row}.'
+#                         + " Ignoring the extras."
+#                     )
+#             # Leading/trailing whitespace in spoken form can prevent recognition.
+#             spoken_form = spoken_form.strip()
+#             mapping[spoken_form] = output
+
+#     return mapping

--- a/src/csv_overrides.py
+++ b/src/csv_overrides.py
@@ -117,6 +117,7 @@ def read_file(path: Path, default_identifiers: list[str]):
     with open(path) as f:
         lines = list(f)
 
+    print(path)
     result = {}
     used_identifiers = []
     has_errors = False
@@ -126,16 +127,16 @@ def read_file(path: Path, default_identifiers: list[str]):
             continue
 
         parts = line.split(",")
-        has_errors = has_errors or csv_assertion(
+        has_errors = has_errors or not csv_assertion(
             len(parts) == 2, path, i, "Malformed csv", line
         )
         key = parts[0].strip()
         value = parts[1].strip()
 
-        has_errors = has_errors or csv_assertion(
+        has_errors = has_errors or not csv_assertion(
             value in default_identifiers, path, i, "Unknown identifier", value
         )
-        has_errors = has_errors or csv_assertion(
+        has_errors = has_errors or not csv_assertion(
             value not in used_identifiers, path, i, "Duplicate identifier", value
         )
 

--- a/src/csv_overrides.py
+++ b/src/csv_overrides.py
@@ -1,11 +1,17 @@
 from .conventions import get_cursorless_list_name
-from talon import Context, actions, fs, app
+from talon import Context, Module, actions, fs, app, settings
 from datetime import datetime
 from pathlib import Path
 
-directory_name = "cursorless-settings"
 
+mod = Module()
 ctx = Context()
+cursorless_settings_directory = mod.setting(
+    "cursorless_settings_directory",
+    type=str,
+    default="cursorless-settings",
+    desc="The directory to use for cursorless settings csvs relative to talon user directory",
+)
 
 
 def init_csv_and_watch_changes(filename: str, default_values: dict[str, dict]):
@@ -181,9 +187,13 @@ def get_file_paths(filename: str):
     if not filename.endswith(".csv"):
         filename = f"{filename}.csv"
     user_dir = actions.path.talon_user()
-    dir_path = Path(user_dir, directory_name)
-    csv_path = Path(dir_path, filename)
-    return dir_path, csv_path
+    settings_directory = Path(cursorless_settings_directory.get())
+
+    if not settings_directory.is_absolute():
+        settings_directory = user_dir / settings_directory
+
+    csv_path = Path(settings_directory, filename)
+    return settings_directory, csv_path
 
 
 def get_super_values(values: dict[str, dict]):

--- a/src/cursorless.talon
+++ b/src/cursorless.talon
@@ -5,17 +5,17 @@ tag(): user.cursorless
 {user.cursorless_simple_action} <user.cursorless_target>:
     user.cursorless_simple_action(cursorless_simple_action, cursorless_target)
 
-<user.cursorless_swap>:
-    user.cursorless_multiple_target_command("swap", cursorless_swap)
+{user.cursorless_swap_action} <user.cursorless_swap_targets>:
+    user.cursorless_multiple_target_command(cursorless_swap_action, cursorless_swap_targets)
 
 {user.cursorless_move_bring_action} <user.cursorless_move_bring_targets>:
     user.cursorless_multiple_target_command(cursorless_move_bring_action, cursorless_move_bring_targets)
 
-<user.cursorless_wrapper> {user.cursorless_wrap_action} <user.cursorless_target>:
-    user.cursorless_single_target_command_with_arg_list("wrap", cursorless_target, cursorless_wrapper)
-
 {user.cursorless_reformat_action} <user.formatters> at <user.cursorless_target>:
     user.cursorless_reformat(cursorless_target, formatters)
+
+<user.cursorless_wrapper> {user.cursorless_wrap_action} <user.cursorless_target>:
+    user.cursorless_single_target_command_with_arg_list("wrap", cursorless_target, cursorless_wrapper)
 
 pour cell:                 user.vscode("jupyter.insertCellBelow")
 drink cell:                user.vscode("jupyter.insertCellAbove")

--- a/src/cursorless.talon
+++ b/src/cursorless.talon
@@ -14,7 +14,7 @@ app: vscode
     user.cursorless_reformat(cursorless_target, formatters)
 
 <user.cursorless_wrapper> {user.cursorless_wrap_action} <user.cursorless_target>:
-    user.cursorless_single_target_command_with_arg_list("wrap", cursorless_target, cursorless_wrapper)
+    user.cursorless_single_target_command_with_arg_list(cursorless_wrap_action, cursorless_target, cursorless_wrapper)
 
 pour cell:                 user.vscode("jupyter.insertCellBelow")
 drink cell:                user.vscode("jupyter.insertCellAbove")

--- a/src/cursorless.talon
+++ b/src/cursorless.talon
@@ -1,6 +1,5 @@
 app: vscode
 -
-tag(): user.cursorless
 
 {user.cursorless_simple_action} <user.cursorless_target>:
     user.cursorless_simple_action(cursorless_simple_action, cursorless_target)

--- a/src/cursorless.talon
+++ b/src/cursorless.talon
@@ -11,10 +11,10 @@ tag(): user.cursorless
 {user.cursorless_move_bring_action} <user.cursorless_move_bring_targets>:
     user.cursorless_multiple_target_command(cursorless_move_bring_action, cursorless_move_bring_targets)
 
-<user.cursorless_wrapper> wrap <user.cursorless_target>:
+<user.cursorless_wrapper> {user.cursorless_wrap_action} <user.cursorless_target>:
     user.cursorless_single_target_command_with_arg_list("wrap", cursorless_target, cursorless_wrapper)
 
-format <user.formatters> at <user.cursorless_target>:
+{user.cursorless_reformat_action} <user.formatters> at <user.cursorless_target>:
     user.cursorless_reformat(cursorless_target, formatters)
 
 pour cell:                 user.vscode("jupyter.insertCellBelow")

--- a/src/cursorless.talon
+++ b/src/cursorless.talon
@@ -16,8 +16,5 @@ app: vscode
 <user.cursorless_wrapper> {user.cursorless_wrap_action} <user.cursorless_target>:
     user.cursorless_single_target_command_with_arg_list(cursorless_wrap_action, cursorless_target, cursorless_wrapper)
 
-pour cell:                 user.vscode("jupyter.insertCellBelow")
-drink cell:                user.vscode("jupyter.insertCellAbove")
-
 cursorless help:           user.cursorless_cheat_sheet_toggle()
 cursorless instructions:   user.cursorless_open_instructions()

--- a/src/marks/lines_number.py
+++ b/src/marks/lines_number.py
@@ -3,10 +3,6 @@ from talon import Context, Module
 mod = Module()
 ctx = Context()
 
-ctx.matches = r"""
-tag: user.cursorless
-"""
-
 mod.list("cursorless_line_direction", desc="Supported directions for line modifier")
 
 directions = {
@@ -63,10 +59,9 @@ def cursorless_line_number(m) -> str:
         },
     }
 
+
 # This is the simplified version that we are using for now that only implements a subset of the features
-@mod.capture(
-    rule="(up | down) <number_small>"
-)
+@mod.capture(rule="(up | down) <number_small>")
 def cursorless_line_number_simple(m) -> str:
     position = {"direction": m[0], "lineNumber": m.number_small}
     return {

--- a/src/marks/mark.py
+++ b/src/marks/mark.py
@@ -18,8 +18,8 @@ hat_colors = {
     "plum": "purple",
 }
 hat_shapes = {
-    "splat": "star",
-    "scoop": "valley",
+    "star": "star",
+    "bird": "chevron",
 }
 
 

--- a/src/marks/mark.py
+++ b/src/marks/mark.py
@@ -1,9 +1,8 @@
 from dataclasses import dataclass
-from talon import Context, Module, app
+from talon import Module, app
 from ..csv_overrides import init_csv_and_watch_changes
 
 mod = Module()
-ctx = Context()
 
 
 mod.list("cursorless_symbol_color", desc="Supported symbol colors for cursorless")

--- a/src/marks/mark.py
+++ b/src/marks/mark.py
@@ -10,7 +10,7 @@ mod.list("cursorless_symbol_color", desc="Supported symbol colors for cursorless
 # NOTE: Please do not change these dicts.  Use the CSVs for customization.
 # See https://github.com/pokey/cursorless-talon/blob/master/docs/customization.md
 symbol_colors = {
-    "gray": "default",
+    "-": "default",
     "blue": "blue",
     "green": "green",
     "rose": "red",

--- a/src/marks/mark.py
+++ b/src/marks/mark.py
@@ -5,31 +5,38 @@ from ..csv_overrides import init_csv_and_watch_changes
 mod = Module()
 
 
-mod.list("cursorless_symbol_color", desc="Supported symbol colors for cursorless")
+mod.list("cursorless_hat_color", desc="Supported hat colors for cursorless")
+mod.list("cursorless_hat_shape", desc="Supported hat shapes for cursorless")
 
 # NOTE: Please do not change these dicts.  Use the CSVs for customization.
 # See https://github.com/pokey/cursorless-talon/blob/master/docs/customization.md
-symbol_colors = {
-    "-": "default",
+hat_colors = {
     "blue": "blue",
     "green": "green",
     "rose": "red",
     "squash": "yellow",
     "plum": "purple",
 }
+hat_shapes = {
+    "splat": "star",
+    "scoop": "valley",
+}
 
 
-@mod.capture(rule="[{user.cursorless_symbol_color}] <user.any_alphanumeric_key>")
+@mod.capture(
+    rule="[{user.cursorless_hat_color}] [{user.cursorless_hat_shape}] <user.any_alphanumeric_key>"
+)
 def cursorless_decorated_symbol(m) -> str:
     """A decorated symbol"""
+    hat_color = getattr(m, "cursorless_hat_color", "default")
     try:
-        symbol_color = m.cursorless_symbol_color
+        hat_style_name = f"{hat_color}-{m.cursorless_hat_shape}"
     except AttributeError:
-        symbol_color = "default"
+        hat_style_name = hat_color
     return {
         "mark": {
             "type": "decoratedSymbol",
-            "symbolColor": symbol_color,
+            "symbolColor": hat_style_name,
             "character": m.any_alphanumeric_key,
         }
     }
@@ -90,9 +97,10 @@ def on_ready():
         },
     )
     init_csv_and_watch_changes(
-        "colors",
+        "hat_styles",
         {
-            "symbol_color": symbol_colors,
+            "hat_color": hat_colors,
+            "hat_shape": hat_shapes,
         },
     )
 

--- a/src/marks/mark.py
+++ b/src/marks/mark.py
@@ -8,7 +8,6 @@ ctx = Context()
 
 
 mod.list("cursorless_hat_color", desc="Supported hat colors for cursorless")
-mod.list("cursorless_hat_shape", desc="Supported hat shapes for cursorless")
 
 # NOTE: Please do not change these dicts.  Use the CSVs for customization.
 # See https://github.com/pokey/cursorless-talon/blob/master/docs/customization.md
@@ -20,28 +19,16 @@ hat_colors = {
     "plum": "purple",
 }
 
-# TODO: Re-add to settings csv
-hat_shapes = {
-    "star": "star",
-    "bird": "chevron",
-}
-ctx.lists[get_cursorless_list_name("hat_shape")] = hat_shapes
 
-
-@mod.capture(
-    rule="[{user.cursorless_hat_color}] [{user.cursorless_hat_shape}] <user.any_alphanumeric_key>"
-)
+@mod.capture(rule="[{user.cursorless_hat_color}] <user.any_alphanumeric_key>")
 def cursorless_decorated_symbol(m) -> str:
     """A decorated symbol"""
     hat_color = getattr(m, "cursorless_hat_color", "default")
-    try:
-        hat_style_name = f"{hat_color}-{m.cursorless_hat_shape}"
-    except AttributeError:
-        hat_style_name = hat_color
+
     return {
         "mark": {
             "type": "decoratedSymbol",
-            "symbolColor": hat_style_name,
+            "symbolColor": hat_color,
             "character": m.any_alphanumeric_key,
         }
     }
@@ -105,8 +92,6 @@ def on_ready():
         "hat_styles",
         {
             "hat_color": hat_colors,
-            # TODO: Re-add to settings csv
-            # "hat_shape": hat_shapes,
         },
     )
 

--- a/src/marks/mark.py
+++ b/src/marks/mark.py
@@ -1,8 +1,10 @@
 from dataclasses import dataclass
-from talon import Module, app
+from ..conventions import get_cursorless_list_name
+from talon import Module, app, Context
 from ..csv_overrides import init_csv_and_watch_changes
 
 mod = Module()
+ctx = Context()
 
 
 mod.list("cursorless_hat_color", desc="Supported hat colors for cursorless")
@@ -17,10 +19,13 @@ hat_colors = {
     "squash": "yellow",
     "plum": "purple",
 }
+
+# TODO: Re-add to settings csv
 hat_shapes = {
     "star": "star",
     "bird": "chevron",
 }
+ctx.lists[get_cursorless_list_name("hat_shape")] = hat_shapes
 
 
 @mod.capture(
@@ -100,7 +105,8 @@ def on_ready():
         "hat_styles",
         {
             "hat_color": hat_colors,
-            "hat_shape": hat_shapes,
+            # TODO: Re-add to settings csv
+            # "hat_shape": hat_shapes,
         },
     )
 

--- a/src/marks/mark.py
+++ b/src/marks/mark.py
@@ -3,9 +3,6 @@ from talon import Context, Module
 mod = Module()
 ctx = Context()
 
-ctx.matches = r"""
-tag: user.cursorless
-"""
 
 mod.list("cursorless_symbol_color", desc="Supported symbol colors for cursorless")
 ctx.lists["self.cursorless_symbol_color"] = {
@@ -51,12 +48,16 @@ ctx.lists["self.cursorless_special_mark"] = special_marks.keys()
         "{user.cursorless_special_mark} |"
         # Because of problems with performance we have to have a simple version for now
         # "<user.cursorless_line_number>" # row, up, down
-        "<user.cursorless_line_number_simple>" # up, down
+        "<user.cursorless_line_number_simple>"  # up, down
     )
 )
 def cursorless_mark(m) -> str:
-    try: return m.cursorless_decorated_symbol
-    except AttributeError: pass
-    try: return special_marks[m.cursorless_special_mark]
-    except AttributeError: pass
+    try:
+        return m.cursorless_decorated_symbol
+    except AttributeError:
+        pass
+    try:
+        return special_marks[m.cursorless_special_mark]
+    except AttributeError:
+        pass
     return m.cursorless_line_number_simple

--- a/src/modifiers/containing_scope.py
+++ b/src/modifiers/containing_scope.py
@@ -6,6 +6,8 @@ mod = Module()
 
 mod.list("cursorless_scope_type", desc="Supported scope types")
 
+# NOTE: Please do not change these dicts.  Use the CSVs for customization.
+# See https://github.com/pokey/cursorless-talon/blob/master/docs/customization.md
 scope_types = {
     "arg": "argumentOrParameter",
     "arrow": "arrowFunction",
@@ -47,6 +49,8 @@ def cursorless_containing_scope(m) -> str:
     }
 
 
+# NOTE: Please do not change these dicts.  Use the CSVs for customization.
+# See https://github.com/pokey/cursorless-talon/blob/master/docs/customization.md
 selection_types = {
     "block": "paragraph",
     "cell": "notebookCell",

--- a/src/modifiers/containing_scope.py
+++ b/src/modifiers/containing_scope.py
@@ -1,13 +1,12 @@
-from talon import Context, Module, app
+from talon import Module, app
 from ..csv_overrides import init_csv_and_watch_changes
 
 mod = Module()
-ctx = Context()
 
 
 mod.list("cursorless_scope_type", desc="Supported scope types")
 
-default_scope_types = {
+scope_types = {
     "arg": "argumentOrParameter",
     "arrow": "arrowFunction",
     "attribute": "attribute",
@@ -20,7 +19,6 @@ default_scope_types = {
     "if state": "ifStatement",
     "item": "collectionItem",
     "key": "collectionKey",
-    "lambda": "arrowFunction",
     "list": "list",
     "map": "dictionary",
     "name": "name",
@@ -49,12 +47,9 @@ def cursorless_containing_scope(m) -> str:
     }
 
 
-def on_csv_change(updated_scope_types):
-    ctx.lists["self.cursorless_scope_type"] = updated_scope_types
-
-
 def on_ready():
-    init_csv_and_watch_changes("scope_types", default_scope_types, on_csv_change)
+    default_values = {"scope_type": scope_types}
+    init_csv_and_watch_changes("scope_types", default_values)
 
 
 app.register("ready", on_ready)

--- a/src/modifiers/containing_scope.py
+++ b/src/modifiers/containing_scope.py
@@ -10,7 +10,6 @@ mod.list("cursorless_scope_type", desc="Supported scope types")
 # See https://github.com/pokey/cursorless-talon/blob/master/docs/customization.md
 scope_types = {
     "arg": "argumentOrParameter",
-    "arrow": "arrowFunction",
     "attribute": "attribute",
     "call": "functionCall",
     "class name": "className",
@@ -21,10 +20,11 @@ scope_types = {
     "if state": "ifStatement",
     "item": "collectionItem",
     "key": "collectionKey",
+    "lambda": "anonymousFunction",
     "list": "list",
-    "map": "dictionary",
+    "map": "map",
     "name": "name",
-    "regex": "regex",
+    "regex": "regularExpression",
     "state": "statement",
     "string": "string",
     "type": "type",
@@ -74,7 +74,7 @@ default_values = {
 
 
 def on_ready():
-    init_csv_and_watch_changes("scope_types", default_values)
+    init_csv_and_watch_changes("modifier_scope_types", default_values)
 
 
 app.register("ready", on_ready)

--- a/src/modifiers/containing_scope.py
+++ b/src/modifiers/containing_scope.py
@@ -3,10 +3,6 @@ from talon import Context, Module
 mod = Module()
 ctx = Context()
 
-ctx.matches = r"""
-tag: user.cursorless
-"""
-
 
 mod.list("cursorless_scope_type", desc="Supported scope types")
 ctx.lists["self.cursorless_scope_type"] = {

--- a/src/modifiers/containing_scope.py
+++ b/src/modifiers/containing_scope.py
@@ -1,11 +1,13 @@
-from talon import Context, Module
+from talon import Context, Module, app
+from ..csv_overrides import init_csv_and_watch_changes
 
 mod = Module()
 ctx = Context()
 
 
 mod.list("cursorless_scope_type", desc="Supported scope types")
-ctx.lists["self.cursorless_scope_type"] = {
+
+default_scope_types = {
     "arg": "argumentOrParameter",
     "arrow": "arrowFunction",
     "attribute": "attribute",
@@ -45,3 +47,14 @@ def cursorless_containing_scope(m) -> str:
             "includeSiblings": m[0] == "every",
         }
     }
+
+
+def on_csv_change(updated_scope_types):
+    ctx.lists["self.cursorless_scope_type"] = updated_scope_types
+
+
+def on_ready():
+    init_csv_and_watch_changes("scope_types", default_scope_types, on_csv_change)
+
+
+app.register("ready", on_ready)

--- a/src/modifiers/containing_scope.py
+++ b/src/modifiers/containing_scope.py
@@ -59,9 +59,17 @@ selection_types = {
     "token": "token",
 }
 
+# NOTE: Please do not change these dicts.  Use the CSVs for customization.
+# See https://github.com/pokey/cursorless-talon/blob/master/docs/customization.md
+subtoken_scope_types = {
+    "word": "word",
+    "char": "character",
+}
+
 default_values = {
     "scope_type": scope_types,
     "selection_type": selection_types,
+    "subtoken_scope_type": subtoken_scope_types,
 }
 
 

--- a/src/modifiers/containing_scope.py
+++ b/src/modifiers/containing_scope.py
@@ -47,8 +47,21 @@ def cursorless_containing_scope(m) -> str:
     }
 
 
+selection_types = {
+    "block": "paragraph",
+    "cell": "notebookCell",
+    "file": "document",
+    "line": "line",
+    "token": "token",
+}
+
+default_values = {
+    "scope_type": scope_types,
+    "selection_type": selection_types,
+}
+
+
 def on_ready():
-    default_values = {"scope_type": scope_types}
     init_csv_and_watch_changes("scope_types", default_values)
 
 

--- a/src/modifiers/head_tail.py
+++ b/src/modifiers/head_tail.py
@@ -3,9 +3,6 @@ from talon import Context, Module
 mod = Module()
 ctx = Context()
 
-ctx.matches = r"""
-tag: user.cursorless
-"""
 
 mod.list("cursorless_head_tail", desc="Cursorless modifier for head or tail of line")
 ctx.lists["self.cursorless_head_tail"] = {"head", "tail"}

--- a/src/modifiers/matching_pair_symbol.py
+++ b/src/modifiers/matching_pair_symbol.py
@@ -4,5 +4,5 @@ mod = Module()
 
 
 @mod.capture(rule="matching")
-def cursorless_matching_pair_symbol(m) -> str:
-    return {"modifier": {"type": "matchingPairSymbol"}}
+def cursorless_matching_paired_delimiter(m) -> str:
+    return {"modifier": {"type": "matchingPairedDelimiter"}}

--- a/src/modifiers/position.py
+++ b/src/modifiers/position.py
@@ -3,10 +3,6 @@ from talon import Context, Module
 mod = Module()
 ctx = Context()
 
-ctx.matches = r"""
-tag: user.cursorless
-"""
-
 
 positions = {
     "after": {"position": "after"},

--- a/src/modifiers/selection_type.py
+++ b/src/modifiers/selection_type.py
@@ -4,9 +4,6 @@ from dataclasses import dataclass
 mod = Module()
 ctx = Context()
 
-ctx.matches = r"""
-tag: user.cursorless
-"""
 
 mod.list("cursorless_selection_type", desc="Types of selection_types")
 ctx.lists["self.cursorless_selection_type"] = {

--- a/src/modifiers/selection_type.py
+++ b/src/modifiers/selection_type.py
@@ -1,28 +1,11 @@
-from talon import Module, app
-from dataclasses import dataclass
-from ..csv_overrides import init_csv_and_watch_changes
+from talon import Module
 
 mod = Module()
 
 
 mod.list("cursorless_selection_type", desc="Types of selection_types")
 
-selection_types = {
-    "token": "token",
-    "line": "line",
-    "block": "paragraph",
-    "file": "document",
-}
-
 
 @mod.capture(rule="{user.cursorless_selection_type}")
 def cursorless_selection_type(m) -> str:
     return {"selectionType": m.cursorless_selection_type}
-
-
-def on_ready():
-    default_values = {"selection_type": selection_types}
-    init_csv_and_watch_changes("selection_types", default_values)
-
-
-app.register("ready", on_ready)

--- a/src/modifiers/selection_type.py
+++ b/src/modifiers/selection_type.py
@@ -1,12 +1,13 @@
-from talon import Context, Module
+from talon import Module, app
 from dataclasses import dataclass
+from ..csv_overrides import init_csv_and_watch_changes
 
 mod = Module()
-ctx = Context()
 
 
 mod.list("cursorless_selection_type", desc="Types of selection_types")
-ctx.lists["self.cursorless_selection_type"] = {
+
+selection_types = {
     "token": "token",
     "line": "line",
     "block": "paragraph",
@@ -17,3 +18,11 @@ ctx.lists["self.cursorless_selection_type"] = {
 @mod.capture(rule="{user.cursorless_selection_type}")
 def cursorless_selection_type(m) -> str:
     return {"selectionType": m.cursorless_selection_type}
+
+
+def on_ready():
+    default_values = {"selection_type": selection_types}
+    init_csv_and_watch_changes("selection_types", default_values)
+
+
+app.register("ready", on_ready)

--- a/src/modifiers/sub_token.py
+++ b/src/modifiers/sub_token.py
@@ -1,13 +1,11 @@
-from talon import Context, Module
+from talon import Module
 
 from ..compound_targets import is_active_included, is_anchor_included
 
 mod = Module()
-ctx = Context()
 
 
-mod.list("cursorless_subtoken", desc="Supported subcomponent types")
-ctx.lists["self.cursorless_subtoken"] = {"word": "word", "char": "character"}
+mod.list("cursorless_subtoken_scope_type", desc="Supported subtoken scope types")
 
 
 @mod.capture(rule="<user.ordinals_small> | last")
@@ -50,10 +48,10 @@ def cursorless_first_last_range(m) -> str:
 @mod.capture(
     rule=(
         "(<user.cursorless_ordinal_range> | <user.cursorless_first_last_range>)"
-        "{user.cursorless_subtoken}"
+        "{user.cursorless_subtoken_scope_type}"
     )
 )
-def cursorless_subtoken(m) -> str:
+def cursorless_subtoken_scope(m) -> str:
     """Subtoken ranges such as subwords or characters"""
     try:
         range = m.cursorless_ordinal_range
@@ -61,5 +59,9 @@ def cursorless_subtoken(m) -> str:
         range = m.cursorless_first_last_range
     return {
         "selectionType": "token",
-        "modifier": {"type": "subpiece", "pieceType": m.cursorless_subtoken, **range},
+        "modifier": {
+            "type": "subpiece",
+            "pieceType": m.cursorless_subtoken_scope_type,
+            **range,
+        },
     }

--- a/src/modifiers/sub_token.py
+++ b/src/modifiers/sub_token.py
@@ -3,9 +3,6 @@ from talon import Context, Module
 mod = Module()
 ctx = Context()
 
-ctx.matches = r"""
-tag: user.cursorless
-"""
 
 mod.list("cursorless_subtoken", desc="Supported subcomponent types")
 ctx.lists["self.cursorless_subtoken"] = {"word": "word", "char": "character"}

--- a/src/modifiers/sub_token.py
+++ b/src/modifiers/sub_token.py
@@ -1,5 +1,7 @@
 from talon import Context, Module
 
+from ..compound_targets import is_active_included, is_anchor_included
+
 mod = Module()
 ctx = Context()
 
@@ -16,12 +18,24 @@ def ordinal_or_last(m) -> str:
     return m.ordinals_small - 1
 
 
-@mod.capture(rule="<user.ordinal_or_last> [past <user.ordinal_or_last>]")
+@mod.capture(
+    rule="<user.ordinal_or_last> [{user.cursorless_range_connective} <user.ordinal_or_last>]"
+)
 def cursorless_ordinal_range(m) -> str:
     """Ordinal range"""
+    try:
+        range_connective = m.cursorless_range_connective
+        include_anchor = is_anchor_included(range_connective)
+        include_active = is_active_included(range_connective)
+    except AttributeError:
+        include_anchor = True
+        include_active = True
+
     return {
         "anchor": m.ordinal_or_last_list[0],
         "active": m.ordinal_or_last_list[-1],
+        "includeAnchor": include_anchor,
+        "includeActive": include_active,
     }
 
 

--- a/src/modifiers/sub_token.py
+++ b/src/modifiers/sub_token.py
@@ -32,8 +32,8 @@ def cursorless_ordinal_range(m) -> str:
     return {
         "anchor": m.ordinal_or_last_list[0],
         "active": m.ordinal_or_last_list[-1],
-        "includeAnchor": include_anchor,
-        "includeActive": include_active,
+        "excludeAnchor": not include_anchor,
+        "excludeActive": not include_active,
     }
 
 

--- a/src/modifiers/surrounding_pair.py
+++ b/src/modifiers/surrounding_pair.py
@@ -1,25 +1,52 @@
-from talon import Context, Module
+from talon import Context, Module, app
+from dataclasses import dataclass
+from ..csv_overrides import init_csv_and_watch_changes
 
 mod = Module()
 ctx = Context()
 
 
-mod.list("cursorless_pair_symbol", desc="A symbol that comes in pairs, eg brackets")
-ctx.lists["self.cursorless_pair_symbol"] = {
-    "skis": "backtickQuotes",
-    "curly": "curlyBrackets",
-    "diamond": "angleBrackets",
-    "quad": "doubleQuotes",
-    "round": "parentheses",
-    "square": "squareBrackets",
-    "twin": "singleQuotes",
+@dataclass
+class PairedDelimiter:
+    defaultSpokenForm: str
+    cursorlessIdentifier: str
+    left: str
+    right: str
+
+
+mod.list(
+    "cursorless_paired_delimiter", desc="A symbol that comes in pairs, eg brackets"
+)
+
+# NOTE: Please do not change these dicts.  Use the CSVs for customization.
+# See https://github.com/pokey/cursorless-talon/blob/master/docs/customization.md
+paired_delimiters = [
+    PairedDelimiter("box", "squareBrackets", "[", "]"),
+    PairedDelimiter("curly", "curlyBrackets", "{", "}"),
+    PairedDelimiter("diamond", "angleBrackets", "<", ">"),
+    PairedDelimiter("escaped quad", "escapedDoubleQuotes", '\\"', '\\"'),
+    PairedDelimiter("escaped twin", "escapedSingleQuotes", "\\'", "\\'"),
+    PairedDelimiter("quad", "doubleQuotes", '"', '"'),
+    PairedDelimiter("round", "parentheses", "(", ")"),
+    PairedDelimiter("skis", "backtickQuotes", "`", "`"),
+    PairedDelimiter("space", "spaces", " ", " "),
+    PairedDelimiter("twin", "singleQuotes", "'", "'"),
+]
+
+paired_delimiters_map = {term.cursorlessIdentifier: term for term in paired_delimiters}
+
+paired_delimiters_defaults = {
+    term.defaultSpokenForm: term.cursorlessIdentifier for term in paired_delimiters
 }
 
 mod.list(
     "cursorless_delimiter_inclusion",
     desc="Whether to include delimiters in surrounding range",
 )
-ctx.lists["self.cursorless_delimiter_inclusion"] = {
+
+# NOTE: Please do not change these dicts.  Use the CSVs for customization.
+# See https://github.com/pokey/cursorless-talon/blob/master/docs/customization.md
+delimiter_inclusions = {
     "inside": "excludeDelimiters",
     "outside": "includeDelimiters",
     "pair": "delimitersOnly",
@@ -28,18 +55,43 @@ ctx.lists["self.cursorless_delimiter_inclusion"] = {
 
 @mod.capture(
     rule=(
-        "[{user.cursorless_delimiter_inclusion}] {user.cursorless_pair_symbol} | "
+        "[{user.cursorless_delimiter_inclusion}] {user.cursorless_paired_delimiter} | "
         "{user.cursorless_delimiter_inclusion}"
     )
 )
 def cursorless_surrounding_pair(m) -> str:
     """Surrounding pair modifier"""
+    paired_delimiter = getattr(m, "cursorless_paired_delimiter", None)
+    if paired_delimiter is None:
+        paired_delimiter_identifier = None
+    else:
+        paired_delimiter_identifier = paired_delimiters_map[
+            paired_delimiter
+        ].cursorlessIdentifier
     return {
         "modifier": {
             "type": "surroundingPair",
-            "delimiter": getattr(m, "cursorless_pair_symbol", None),
+            "delimiter": paired_delimiter_identifier,
             "delimiterInclusion": getattr(
                 m, "cursorless_delimiter_inclusion", "includeDelimiters"
             ),
         },
     }
+
+
+def on_ready():
+    init_csv_and_watch_changes(
+        "paired_delimiters",
+        {
+            "paired_delimiter": paired_delimiters_defaults,
+        },
+    )
+    init_csv_and_watch_changes(
+        "delimiter_inclusions",
+        {
+            "delimiter_inclusion": delimiter_inclusions,
+        },
+    )
+
+
+app.register("ready", on_ready)

--- a/src/modifiers/surrounding_pair.py
+++ b/src/modifiers/surrounding_pair.py
@@ -1,42 +1,9 @@
 from talon import Module, app
-from dataclasses import dataclass
+from ..paired_delimiter import paired_delimiters_map
 from ..csv_overrides import init_csv_and_watch_changes
 
 mod = Module()
 
-
-@dataclass
-class PairedDelimiter:
-    defaultSpokenForm: str
-    cursorlessIdentifier: str
-    left: str
-    right: str
-
-
-mod.list(
-    "cursorless_paired_delimiter", desc="A symbol that comes in pairs, eg brackets"
-)
-
-# NOTE: Please do not change these dicts.  Use the CSVs for customization.
-# See https://github.com/pokey/cursorless-talon/blob/master/docs/customization.md
-paired_delimiters = [
-    PairedDelimiter("curly", "curlyBrackets", "{", "}"),
-    PairedDelimiter("diamond", "angleBrackets", "<", ">"),
-    PairedDelimiter("escaped quad", "escapedDoubleQuotes", '\\"', '\\"'),
-    PairedDelimiter("escaped twin", "escapedSingleQuotes", "\\'", "\\'"),
-    PairedDelimiter("quad", "doubleQuotes", '"', '"'),
-    PairedDelimiter("round", "parentheses", "(", ")"),
-    PairedDelimiter("skis", "backtickQuotes", "`", "`"),
-    PairedDelimiter("space", "spaces", " ", " "),
-    PairedDelimiter("square", "squareBrackets", "[", "]"),
-    PairedDelimiter("twin", "singleQuotes", "'", "'"),
-]
-
-paired_delimiters_map = {term.cursorlessIdentifier: term for term in paired_delimiters}
-
-paired_delimiters_defaults = {
-    term.defaultSpokenForm: term.cursorlessIdentifier for term in paired_delimiters
-}
 
 mod.list(
     "cursorless_delimiter_inclusion",
@@ -80,13 +47,7 @@ def cursorless_surrounding_pair(m) -> str:
 
 def on_ready():
     init_csv_and_watch_changes(
-        "paired_delimiters",
-        {
-            "paired_delimiter": paired_delimiters_defaults,
-        },
-    )
-    init_csv_and_watch_changes(
-        "delimiter_inclusions",
+        "modifier_surrounding_pair",
         {
             "delimiter_inclusion": delimiter_inclusions,
         },

--- a/src/modifiers/surrounding_pair.py
+++ b/src/modifiers/surrounding_pair.py
@@ -20,7 +20,6 @@ mod.list(
 # NOTE: Please do not change these dicts.  Use the CSVs for customization.
 # See https://github.com/pokey/cursorless-talon/blob/master/docs/customization.md
 paired_delimiters = [
-    PairedDelimiter("box", "squareBrackets", "[", "]"),
     PairedDelimiter("curly", "curlyBrackets", "{", "}"),
     PairedDelimiter("diamond", "angleBrackets", "<", ">"),
     PairedDelimiter("escaped quad", "escapedDoubleQuotes", '\\"', '\\"'),
@@ -29,6 +28,7 @@ paired_delimiters = [
     PairedDelimiter("round", "parentheses", "(", ")"),
     PairedDelimiter("skis", "backtickQuotes", "`", "`"),
     PairedDelimiter("space", "spaces", " ", " "),
+    PairedDelimiter("square", "squareBrackets", "[", "]"),
     PairedDelimiter("twin", "singleQuotes", "'", "'"),
 ]
 

--- a/src/modifiers/surrounding_pair.py
+++ b/src/modifiers/surrounding_pair.py
@@ -3,10 +3,6 @@ from talon import Context, Module
 mod = Module()
 ctx = Context()
 
-ctx.matches = r"""
-tag: user.cursorless
-"""
-
 
 mod.list("cursorless_pair_symbol", desc="A symbol that comes in pairs, eg brackets")
 ctx.lists["self.cursorless_pair_symbol"] = {

--- a/src/modifiers/surrounding_pair.py
+++ b/src/modifiers/surrounding_pair.py
@@ -45,13 +45,14 @@ def cursorless_surrounding_pair(m) -> str:
     }
 
 
-def on_ready():
-    init_csv_and_watch_changes(
-        "modifier_surrounding_pair",
-        {
-            "delimiter_inclusion": delimiter_inclusions,
-        },
-    )
+# TODO: add these to a "modifiers" csv
+# def on_ready():
+#     init_csv_and_watch_changes(
+#         "modifiers",
+#         {
+#             "delimiter_inclusion": delimiter_inclusions,
+#         },
+#     )
 
 
-app.register("ready", on_ready)
+# app.register("ready", on_ready)

--- a/src/modifiers/surrounding_pair.py
+++ b/src/modifiers/surrounding_pair.py
@@ -1,9 +1,8 @@
-from talon import Context, Module, app
+from talon import Module, app
 from dataclasses import dataclass
 from ..csv_overrides import init_csv_and_watch_changes
 
 mod = Module()
-ctx = Context()
 
 
 @dataclass

--- a/src/paired_delimiter.py
+++ b/src/paired_delimiter.py
@@ -1,0 +1,50 @@
+from talon import Module, app
+from dataclasses import dataclass
+from .csv_overrides import init_csv_and_watch_changes
+
+mod = Module()
+mod.list(
+    "cursorless_paired_delimiter", desc="A symbol that comes in pairs, eg brackets"
+)
+
+
+@dataclass
+class PairedDelimiter:
+    defaultSpokenForm: str
+    cursorlessIdentifier: str
+    left: str
+    right: str
+
+
+# NOTE: Please do not change these dicts.  Use the CSVs for customization.
+# See https://github.com/pokey/cursorless-talon/blob/master/docs/customization.md
+paired_delimiters = [
+    PairedDelimiter("curly", "curlyBrackets", "{", "}"),
+    PairedDelimiter("diamond", "angleBrackets", "<", ">"),
+    PairedDelimiter("escaped quad", "escapedDoubleQuotes", '\\"', '\\"'),
+    PairedDelimiter("escaped twin", "escapedSingleQuotes", "\\'", "\\'"),
+    PairedDelimiter("quad", "doubleQuotes", '"', '"'),
+    PairedDelimiter("round", "parentheses", "(", ")"),
+    PairedDelimiter("skis", "backtickQuotes", "`", "`"),
+    PairedDelimiter("void", "whitespace", " ", " "),
+    PairedDelimiter("square", "squareBrackets", "[", "]"),
+    PairedDelimiter("twin", "singleQuotes", "'", "'"),
+]
+
+paired_delimiters_map = {term.cursorlessIdentifier: term for term in paired_delimiters}
+
+paired_delimiters_defaults = {
+    term.defaultSpokenForm: term.cursorlessIdentifier for term in paired_delimiters
+}
+
+
+def on_ready():
+    init_csv_and_watch_changes(
+        "paired_delimiters",
+        {
+            "paired_delimiter": paired_delimiters_defaults,
+        },
+    )
+
+
+app.register("ready", on_ready)

--- a/src/primitive_target.py
+++ b/src/primitive_target.py
@@ -21,7 +21,7 @@ modifiers = [
     "<user.cursorless_containing_scope>",  # funk, state, class
     "<user.cursorless_subtoken>",  # first past second word
     # "<user.cursorless_surrounding_pair>",  # matching/pair [curly, round]
-    # "<user.cursorless_matching_pair_symbol>",  # matching
+    # "<user.cursorless_matching_paired_delimiter>",  # matching
 ]
 
 

--- a/src/primitive_target.py
+++ b/src/primitive_target.py
@@ -19,7 +19,7 @@ modifiers = [
     "<user.cursorless_selection_type>",  # token, line, file
     "<user.cursorless_head_tail>",  # head, tail
     "<user.cursorless_containing_scope>",  # funk, state, class
-    "<user.cursorless_subtoken>",  # first past second word
+    "<user.cursorless_subtoken_scope>",  # first past second word
     # "<user.cursorless_surrounding_pair>",  # matching/pair [curly, round]
     # "<user.cursorless_matching_paired_delimiter>",  # matching
 ]

--- a/src/tag.py
+++ b/src/tag.py
@@ -1,4 +1,0 @@
-from talon import Module
-
-mod = Module()
-mod.tag("cursorless", "Tag to activate all cursorless features")

--- a/src/util.py
+++ b/src/util.py
@@ -1,0 +1,5 @@
+def flat_dicts(dicts: list[dict]):
+    result = {}
+    for dict in dicts:
+        result.update(dict)
+    return result

--- a/src/util.py
+++ b/src/util.py
@@ -1,5 +1,0 @@
-def flat_dicts(dicts: list[dict]):
-    result = {}
-    for dict in dicts:
-        result.update(dict)
-    return result


### PR DESCRIPTION
To do:
- [x] Add docs
- [x] Link to docs from before every defaults list
- [x] Make "cell" a proper scope type
- [x] Support user removing an item either by commenting it or using special identifier
- [x] Surrounding pair types
- [x] Compound range terms
- [x] Minor cheatsheet cleanup
- [x] Change "list specifier" to "list connective"?
- [x] Make csv location customizable
- [x] Use range specifier for subtoken ranges
- [x] Change "box" to "square", then change back a week or two after release so new users will have that default
- [x] Move range connective stuff to `connective.py` and use it for bring / move / swap
- [x] Use user-defined connectives in cheatsheet and switch to f-strings
- [x] Update docs to mention configurable location
- [x] Update doc string for csv watcher func
- [x] Figure out exclude / include for subtokens
- [x] See if we need a mapping for scope type deprecations
- [x] Make "inside" / "outside" available everywhere again

Won't do:
- [x] Positions (treatment of these is still in flux, so maybe let's hold off for now)
- [x] Make "string" into a surrounding pair instead of a syntactic scope