### PR TITLE
Make error handling more robust

### DIFF
--- a/src/actions/actions.py
+++ b/src/actions/actions.py
@@ -18,11 +18,9 @@ class MakeshiftAction:
 
 
 makeshift_actions = [
-    MakeshiftAction("drink cell", "editNewCellAbove", "jupyter.insertCellAbove"),
     MakeshiftAction("define", "revealDefinition", "editor.action.revealDefinition"),
     MakeshiftAction("hover", "showHover", "editor.action.showHover"),
     MakeshiftAction("inspect", "showDebugHover", "editor.debug.action.showDebugHover"),
-    MakeshiftAction("pour cell", "editNewCellBelow", "jupyter.insertCellBelow"),
     MakeshiftAction(
         "quick fix", "quickFix", "editor.action.quickFix", pre_command_sleep=0.3
     ),

--- a/src/csv_overrides.py
+++ b/src/csv_overrides.py
@@ -76,11 +76,14 @@ def update_file(path: Path, default_values: dict):
             ]
             write_file(path, lines, "a")
 
-            message = f"🎉🎉 New cursorless features in {path.name}"
-            print(message)
+            print(f"New cursorless features added to {path.name}")
             for key in sorted(missing):
                 print(f"{key}: {missing[key]}")
-            app.notify(message)
+            print(
+                "See release notes for more info: "
+                "https://github.com/pokey/cursorless-vscode/blob/master/CHANGELOG.md"
+            )
+            app.notify(f"🎉🎉 New cursorless features; see log")
 
     return current_values
 

--- a/src/csv_overrides.py
+++ b/src/csv_overrides.py
@@ -101,9 +101,7 @@ def csv_error(path: Path, index: int, message: str, value: str):
         index (int): The index into the file (for error reporting)
         text (str): The text of the error message to report if condition is false
     """
-    error_message = f"ERROR: {path}:{index+1}: {message} '{value}'"
-    app.notify("Cursorless settings error; see log")
-    print(error_message)
+    print(f"ERROR: {path}:{index+1}: {message} '{value}'")
 
 
 def read_file(path: Path, default_identifiers: list[str]):
@@ -137,6 +135,9 @@ def read_file(path: Path, default_identifiers: list[str]):
 
         result[key] = value
         used_identifiers.append(value)
+
+    if has_errors:
+        app.notify("Cursorless settings error; see log")
 
     return result, has_errors
 

--- a/src/csv_overrides.py
+++ b/src/csv_overrides.py
@@ -117,6 +117,7 @@ def read_file(path: Path, default_identifiers: list[str]):
     with open(path) as f:
         lines = list(f)
 
+    print(path)
     result = {}
     used_identifiers = []
     has_errors = False
@@ -126,16 +127,16 @@ def read_file(path: Path, default_identifiers: list[str]):
             continue
 
         parts = line.split(",")
-        has_errors = has_errors or csv_assertion(
+        has_errors = has_errors or not csv_assertion(
             len(parts) == 2, path, i, "Malformed csv", line
         )
         key = parts[0].strip()
         value = parts[1].strip()
 
-        has_errors = has_errors or csv_assertion(
+        has_errors = has_errors or not csv_assertion(
             value in default_identifiers, path, i, "Unknown identifier", value
         )
-        has_errors = has_errors or csv_assertion(
+        has_errors = has_errors or not csv_assertion(
             value not in used_identifiers, path, i, "Duplicate identifier", value
         )
 

--- a/src/cursorless.talon
+++ b/src/cursorless.talon
@@ -16,8 +16,5 @@ app: vscode
 <user.cursorless_wrapper> {user.cursorless_wrap_action} <user.cursorless_target>:
     user.cursorless_single_target_command_with_arg_list(cursorless_wrap_action, cursorless_target, cursorless_wrapper)
 
-pour cell:                 user.vscode("jupyter.insertCellBelow")
-drink cell:                user.vscode("jupyter.insertCellAbove")
-
 cursorless help:           user.cursorless_cheat_sheet_toggle()
 cursorless instructions:   user.cursorless_open_instructions()

--- a/src/modifiers/containing_scope.py
+++ b/src/modifiers/containing_scope.py
@@ -47,8 +47,21 @@ def cursorless_containing_scope(m) -> str:
     }
 
 
+selection_types = {
+    "block": "paragraph",
+    "cell": "notebookCell",
+    "file": "document",
+    "line": "line",
+    "token": "token",
+}
+
+default_values = {
+    "scope_type": scope_types,
+    "selection_type": selection_types,
+}
+
+
 def on_ready():
-    default_values = {"scope_type": scope_types}
     init_csv_and_watch_changes("scope_types", default_values)
 
 

--- a/src/modifiers/selection_type.py
+++ b/src/modifiers/selection_type.py
@@ -1,28 +1,11 @@
-from talon import Module, app
-from dataclasses import dataclass
-from ..csv_overrides import init_csv_and_watch_changes
+from talon import Module
 
 mod = Module()
 
 
 mod.list("cursorless_selection_type", desc="Types of selection_types")
 
-selection_types = {
-    "token": "token",
-    "line": "line",
-    "block": "paragraph",
-    "file": "document",
-}
-
 
 @mod.capture(rule="{user.cursorless_selection_type}")
 def cursorless_selection_type(m) -> str:
     return {"selectionType": m.cursorless_selection_type}
-
-
-def on_ready():
-    default_values = {"selection_type": selection_types}
-    init_csv_and_watch_changes("selection_types", default_values)
-
-
-app.register("ready", on_ready)


### PR DESCRIPTION
This way csv reader will try to recover from errors so that cursorless isn't bricked when you have a malformed line.  Note that it won't try to update the csv if there were errors