### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This repository contains the talon side of [Cursorless](https://marketplace.visualstudio.com/items?itemName=pokey.cursorless).  
 
 ## Documentation
-Full documentation can be found in [docs](docs/), or by saying `"cursorless docs"`. Once you understand the concepts, you can pull up a cheat cheat for reference using the command `"cursorless help"`.
+Full documentation can be found in [docs](docs/), or by saying `"cursorless docs"`. Once you understand the concepts, you can pull up a cheatsheet for reference using the command `"cursorless help"`.
 
 ## Installation
 First, install the dependencies:

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 # Cursorless - Instructions
 You may find it helpful to start with the [tutorial video](https://www.youtube.com/watch?v=JxcNW0hnfTk).
 
-Once you understand the concepts, you can pull up a cheat cheat for reference using the command `"cursorless help"`.
+Once you understand the concepts, you can pull up a cheatsheet for reference using the command `"cursorless help"`.
 
 You can get back to these docs by saying `"cursorless docs"`.
 


### PR DESCRIPTION
replace "cheat cheat" with "cheatsheet" in docs