### PR TITLE
Moved wrap action to talon file

### DIFF
--- a/src/actions/replace.py
+++ b/src/actions/replace.py
@@ -6,5 +6,5 @@ mod = Module()
 @mod.action_class
 class Actions:
     def cursorless_replace(target: dict, texts: list[str] or dict):
-        """Replaced targets with texts"""
+        """Replace targets with texts"""
         actions.user.cursorless_single_target_command("replace", target, texts)

--- a/src/actions/wrap.py
+++ b/src/actions/wrap.py
@@ -31,9 +31,7 @@ wrapper_snippets = {
 
 
 @mod.capture(
-    rule=(
-        "(<user.cursorless_wrapper_paired_delimiter> | {user.cursorless_wrapper_snippet}) {user.cursorless_wrap_action}"
-    )
+    rule="<user.cursorless_wrapper_paired_delimiter> | {user.cursorless_wrapper_snippet}"
 )
 def cursorless_wrapper(m) -> Union[list[str], str]:
     try:

--- a/src/cursorless.talon
+++ b/src/cursorless.talon
@@ -13,7 +13,7 @@ app: vscode
 {user.cursorless_reformat_action} <user.formatters> at <user.cursorless_target>:
     user.cursorless_reformat(cursorless_target, formatters)
 
-<user.cursorless_wrapper> <user.cursorless_target>:
+<user.cursorless_wrapper> {user.cursorless_wrap_action} <user.cursorless_target>:
     user.cursorless_wrap(cursorless_wrapper, cursorless_target)
 
 cursorless help:           user.cursorless_cheat_sheet_toggle()


### PR DESCRIPTION
All the other voice commands have their action defined in cursorless.talon. Moved for uniformity and readability.